### PR TITLE
Fix expression syntax code and docs

### DIFF
--- a/pkg/expansion/expand_match.go
+++ b/pkg/expansion/expand_match.go
@@ -12,7 +12,7 @@ type ExpandRegexMatch struct {
 	Only   []string
 }
 
-var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*://[^\+]+)\+?`)
+var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*://[^\+\n]+)\+?`)
 
 func (e *ExpandRegexMatch) InString(s string) (string, error) {
 	var sb strings.Builder

--- a/pkg/expansion/expand_match_test.go
+++ b/pkg/expansion/expand_match_test.go
@@ -87,6 +87,22 @@ func TestExpandRegexpMatchInString(t *testing.T) {
 			input:    "\"no-referrer\" always;\nreturn 301 $scheme://$host:$server_port/remote.php/dav;",
 			expected: "\"no-referrer\" always;\nreturn 301 $scheme://$host:$server_port/remote.php/dav;",
 		},
+		{
+			// see https://github.com/helmfile/vals/issues/57
+			name:     "it should skip newline after fragment",
+			regex:    DefaultRefRegexp,
+			only:     []string{"ref", "secretref"},
+			input:    "ref+vault://srv/foo/bar#certificate\n",
+			expected: "vault-srv-/foo/bar\n",
+		},
+		{
+			// see https://github.com/helmfile/vals/issues/57
+			name:     "it should skip newline after path",
+			regex:    DefaultRefRegexp,
+			only:     []string{"ref", "secretref"},
+			input:    "ref+vault://srv/foo/bar\n",
+			expected: "vault-srv-/foo/bar\n",
+		},
 	}
 
 	for i := range testcases {


### PR DESCRIPTION
Fix the expression syntax to treat new line as the expression terminator to directly fix the issue reported in #57.

I've also updated the documentation with the brand-new "expression syntax" that covers the new treatment of the new-line, so that it's more clear what is supposed to work or not.

Resolves #57

Signed-off-by: Yusuke Kuoka <ykuoka@gmail.com>