### PR TITLE
feat: vals-exec --stream-yaml $FILE to stream vals-eval result to stdin of another command

### DIFF
--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -104,26 +104,12 @@ func main() {
 
 		nodes := readNodesOrFail(f)
 
-		var res []yaml.Node
-		for _, node := range nodes {
-			var nodeValue map[string]interface{}
-			err := node.Decode(&nodeValue)
-			if err != nil {
-				fatal("%v", err)
-			}
-			evalResult, err := vals.Eval(nodeValue,
-				vals.Options{
-					ExcludeSecret: *e,
-					LogOutput:     logOut,
-				})
-			if err != nil {
-				fatal("%v", err)
-			}
-			err = node.Encode(evalResult)
-			if err != nil {
-				fatal("%v", err)
-			}
-			res = append(res, node)
+		res, err := vals.EvalNodes(nodes, vals.Options{
+			ExcludeSecret: *e,
+			LogOutput:     logOut,
+		})
+		if err != nil {
+			fatal("%v", err)
 		}
 
 		writeOrFail(o, res)

--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -157,14 +157,29 @@ func main() {
 	case CmdExec:
 		execCmd := flag.NewFlagSet(CmdExec, flag.ExitOnError)
 		f := execCmd.String("f", "", "YAML/JSON file to be loaded to set envvars")
+		streamYAML := execCmd.String("stream-yaml", "", `Reads the specific YAML file or all the YAML files
+stored within the specific directory, evaluate each YAML file,
+joining all the YAML files with "---" lines, and stream the
+result into the stdin of the executed command.
+This is handy when you want to use vals to preprocess
+Kubernetes manifests to kubectl-apply, without writing
+the vals-eval outputs onto the disk, for security reasons.`)
 		err := execCmd.Parse(os.Args[2:])
 		if err != nil {
 			fatal("%v", err)
 		}
 
-		m := readOrFail(f)
+		var m map[string]interface{}
 
-		err = vals.Exec(m, execCmd.Args())
+		if *f != "" {
+			m = readOrFail(f)
+		} else {
+			m = map[string]interface{}{}
+		}
+
+		err = vals.Exec(m, execCmd.Args(), vals.ExecConfig{
+			StreamYAML: *streamYAML,
+		})
 		if err != nil {
 			fatal("%v", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/vault/api v1.0.4
+	github.com/stretchr/testify v1.7.0
 	go.mozilla.org/sops/v3 v3.7.1
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 	google.golang.org/api v0.95.0
@@ -44,6 +45,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/alecthomas/participle v0.4.2-0.20191220090139-9fbceec1d131 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
@@ -84,6 +86,7 @@ require (
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect

--- a/io.go
+++ b/io.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -19,6 +20,33 @@ func Inputs(f string) ([]yaml.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		info, err := fp.Stat()
+		if err != nil {
+			return nil, err
+		}
+
+		if info.IsDir() {
+			entries, err := fp.ReadDir(0)
+			if err != nil {
+				return nil, err
+			}
+
+			var nodes []yaml.Node
+
+			for _, e := range entries {
+				s := filepath.Join(f, e.Name())
+				ns, err := Inputs(s)
+				if err != nil {
+					return nil, err
+				}
+
+				nodes = append(nodes, ns...)
+			}
+
+			return nodes, nil
+		}
+
 		reader = fp
 		defer func() {
 			_ = fp.Close()

--- a/stream_yaml.go
+++ b/stream_yaml.go
@@ -1,0 +1,14 @@
+package vals
+
+import (
+	"io"
+)
+
+func streamYAML(path string, w io.Writer) error {
+	nodes, err := Inputs(path)
+	if err != nil {
+		return err
+	}
+
+	return Output(w, "yaml", nodes)
+}

--- a/stream_yaml.go
+++ b/stream_yaml.go
@@ -4,8 +4,13 @@ import (
 	"io"
 )
 
-func streamYAML(path string, w io.Writer) error {
+func streamYAML(path string, w, log io.Writer) error {
 	nodes, err := Inputs(path)
+	if err != nil {
+		return err
+	}
+
+	nodes, err = EvalNodes(nodes, Options{LogOutput: log})
 	if err != nil {
 		return err
 	}

--- a/vals_test.go
+++ b/vals_test.go
@@ -1,0 +1,33 @@
+package vals
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExec(t *testing.T) {
+	dir := t.TempDir()
+
+	// should evaluate to "x: baz"
+	data := []byte("x: ref+echo://foo/bar/baz#/foo/bar")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "input.yaml"), data, 0644))
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	c := ExecConfig{
+		StreamYAML: dir,
+		Stdout:     stdout,
+		Stderr:     stderr,
+	}
+
+	err := Exec(map[string]interface{}{}, []string{"cat"}, c)
+	require.NoError(t, err)
+
+	require.Equal(t, "x: baz\n", stdout.String())
+}


### PR DESCRIPTION
We already have a command `vals exec` which is usually run like `vals exec -f env.yaml -- other command` so that the other command is run using the fetched secrets as the envvars.

This change makes the `-f` flag optional and adds the new flag `-stream-yaml`.

The new flag instructs vals to read the yaml, run `vals eval` against it, and pipe the result into the stdin of the other command. This is handy when you want more security, by not writing data ccontaining fetched secrets onto the local disk.

For example, `vals exec --stream-yaml objs.yaml -- kubectl apply -f -` is considered a more secure alternative to running `vals eval -f objs.yaml > tmp.yaml && kubectl apply -f tmp.yaml`.