### PR TITLE
Quote vals' env command variable values when needed

### DIFF
--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -180,7 +180,7 @@ the vals-eval outputs onto the disk, for security reasons.`)
 
 		m := readOrFail(f)
 
-		env, err := vals.Env(m)
+		env, err := vals.QuotedEnv(m)
 		if err != nil {
 			fatal("%v", err)
 		}

--- a/vals_test.go
+++ b/vals_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,4 +31,48 @@ func TestExec(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "x: baz\n", stdout.String())
+}
+
+func TestEnv(t *testing.T) {
+	input := make(map[string]interface{})
+
+	input["var1"] = "ref+echo://value"
+	input["var2"] = "ref+echo://val;ue"
+	input["var3"] = "ref+echo://val'ue"
+	input["var4"] = "ref+echo://'value"
+
+	var expected = []string{
+		"var1=value",
+		"var2=val;ue",
+		"var3=val'ue",
+		"var4='value",
+	}
+
+	got, err := Env(input)
+	require.NoError(t, err)
+
+	sort.Strings(got)
+	require.Equal(t, expected, got)
+}
+
+func TestQuotedEnv(t *testing.T) {
+	input := make(map[string]interface{})
+
+	input["var1"] = "ref+echo://value"
+	input["var2"] = "ref+echo://val;ue"
+	input["var3"] = "ref+echo://val'ue"
+	input["var4"] = "ref+echo://'value"
+
+	var expected = []string{
+		"var1=value",
+		`var2='val;ue'`,
+		`var3='val'"'"'ue'`,
+		`var4=''"'"'value'`,
+	}
+
+	got, err := QuotedEnv(input)
+	require.NoError(t, err)
+
+	sort.Strings(got)
+	require.Equal(t, expected, got)
 }


### PR DESCRIPTION
To make vals' env command's output usable by a shell, emitted variable values containing "unsafe" characters are quoted.