### PR TITLE
Add new options to exec command

### DIFF
--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -174,7 +174,7 @@ the vals-eval outputs onto the disk, for security reasons.`)
 
 		err = vals.Exec(m, execCmd.Args(), vals.ExecConfig{
 			InheritEnv: *inheritEnv,
-			Options: vals.Options{LogOutput: logOut},
+			Options:    vals.Options{LogOutput: logOut},
 			StreamYAML: *streamYAML,
 		})
 		if err != nil {

--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -146,6 +146,7 @@ func main() {
 		execCmd := flag.NewFlagSet(CmdExec, flag.ExitOnError)
 		f := execCmd.String("f", "", "YAML/JSON file to be loaded to set envvars")
 		inheritEnv := execCmd.Bool("i", false, "Inherit environment variables")
+		silent := execCmd.Bool("s", false, "Silent mode")
 		streamYAML := execCmd.String("stream-yaml", "", `Reads the specific YAML file or all the YAML files
 stored within the specific directory, evaluate each YAML file,
 joining all the YAML files with "---" lines, and stream the
@@ -166,8 +167,14 @@ the vals-eval outputs onto the disk, for security reasons.`)
 			m = map[string]interface{}{}
 		}
 
+		var logOut io.Writer = os.Stderr
+		if *silent {
+			logOut = io.Discard
+		}
+
 		err = vals.Exec(m, execCmd.Args(), vals.ExecConfig{
 			InheritEnv: *inheritEnv,
+			Options: vals.Options{LogOutput: logOut},
 			StreamYAML: *streamYAML,
 		})
 		if err != nil {

--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -145,6 +145,7 @@ func main() {
 	case CmdExec:
 		execCmd := flag.NewFlagSet(CmdExec, flag.ExitOnError)
 		f := execCmd.String("f", "", "YAML/JSON file to be loaded to set envvars")
+		inheritEnv := execCmd.Bool("i", false, "Inherit environment variables")
 		streamYAML := execCmd.String("stream-yaml", "", `Reads the specific YAML file or all the YAML files
 stored within the specific directory, evaluate each YAML file,
 joining all the YAML files with "---" lines, and stream the
@@ -166,6 +167,7 @@ the vals-eval outputs onto the disk, for security reasons.`)
 		}
 
 		err = vals.Exec(m, execCmd.Args(), vals.ExecConfig{
+			InheritEnv: *inheritEnv,
 			StreamYAML: *streamYAML,
 		})
 		if err != nil {

--- a/vals.go
+++ b/vals.go
@@ -452,8 +452,8 @@ type Options struct {
 
 var unsafeCharRegexp = regexp.MustCompile(`[^\w@%+=:,./-]`)
 
-func env(template map[string]interface{}, quote bool) ([]string, error) {
-	m, err := Eval(template)
+func env(template map[string]interface{}, quote bool, o ...Options) ([]string, error) {
+	m, err := Eval(template, o...)
 	if err != nil {
 		return nil, err
 	}
@@ -475,9 +475,9 @@ func env(template map[string]interface{}, quote bool) ([]string, error) {
 	return env, nil
 }
 
-func applyEnvWithQuote(quote bool) func(map[string]interface{}) ([]string, error) {
-	return func(template map[string]interface{}) ([]string, error) {
-		return env(template, quote)
+func applyEnvWithQuote(quote bool) func(map[string]interface{}, ...Options) ([]string, error) {
+	return func(template map[string]interface{}, o ...Options) ([]string, error) {
+		return env(template, quote, o...)
 	}
 }
 
@@ -486,6 +486,7 @@ var QuotedEnv = applyEnvWithQuote(true)
 
 type ExecConfig struct {
 	InheritEnv bool
+	Options Options
 	// StreamYAML reads the specific YAML file or all the YAML files
 	// stored within the specific directory, evaluate each YAML file,
 	// joining all the YAML files with "---" lines, and stream the
@@ -517,7 +518,7 @@ func Exec(template map[string]interface{}, args []string, config ...ExecConfig) 
 	if len(args) == 0 {
 		return errors.New("missing args")
 	}
-	env, err := Env(template)
+	env, err := Env(template, c.Options)
 	if err != nil {
 		return err
 	}

--- a/vals.go
+++ b/vals.go
@@ -485,6 +485,7 @@ var Env = applyEnvWithQuote(false)
 var QuotedEnv = applyEnvWithQuote(true)
 
 type ExecConfig struct {
+	InheritEnv bool
 	// StreamYAML reads the specific YAML file or all the YAML files
 	// stored within the specific directory, evaluate each YAML file,
 	// joining all the YAML files with "---" lines, and stream the
@@ -519,6 +520,10 @@ func Exec(template map[string]interface{}, args []string, config ...ExecConfig) 
 	env, err := Env(template)
 	if err != nil {
 		return err
+	}
+
+	if c.InheritEnv {
+		env = append(os.Environ(), env...)
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)

--- a/vals.go
+++ b/vals.go
@@ -486,7 +486,7 @@ var QuotedEnv = applyEnvWithQuote(true)
 
 type ExecConfig struct {
 	InheritEnv bool
-	Options Options
+	Options    Options
 	// StreamYAML reads the specific YAML file or all the YAML files
 	// stored within the specific directory, evaluate each YAML file,
 	// joining all the YAML files with "---" lines, and stream the


### PR DESCRIPTION
Add two new options to `exec` command:
- `-s`, like other commands, for so called "silent mode"
- `-i`  to have environment inherits variables before being populated/modified 