### PR TITLE
Add Azure Subscription ID support per value

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,12 +397,15 @@ Examples:
 
 ### Terraform (tfstate)
 
-- `ref+tfstate://relative/path/to/some.tfstate/RESOURCE_NAME[?aws_profile=AWS_POFILE]`
-- `ref+tfstate:///absolute/path/to/some.tfstate/RESOURCE_NAME[?aws_profile=AWS_POFILE]`
+- `ref+tfstate://relative/path/to/some.tfstate/RESOURCE_NAME[?aws_profile=AWS_PROFILE]`
+- `ref+tfstate:///absolute/path/to/some.tfstate/RESOURCE_NAME[?aws_profile=AWS_PROFILE]`
+- `ref+tfstate://relative/path/to/some.tfstate/RESOURCE_NAME[?az_subscription_id=AZ_SUBSCRIPTION_ID]`
+- `ref+tfstate:///absolute/path/to/some.tfstate/RESOURCE_NAME[?az_subscription_id=AZ_SUBSCRIPTION_ID]`
 
 Options:
 
 `aws_profile`: If non-empty, `vals` tries to let tfstate-lookup to use the specified AWS profile defined in the well-known `~/.credentials` file.
+`az_subscription_id`: If non-empty, `vals` tries to let tfstate-lookup to use the specified Azure Subscription ID.
 
 Examples:
 
@@ -494,11 +497,12 @@ $ echo 'foo: ref+tfstates3://bucket-with-terraform-state/terraform.tfstate/modul
 ```
 ### Terraform in AzureRM Blob storage (tfstateazurerm)
 
-- `ref+tfstateazurerm://{resource_group_name}/{storage_account_name}/{container_name}/{blob_name}.tfstate/RESOURCE_NAME`
+- `ref+tfstateazurerm://{resource_group_name}/{storage_account_name}/{container_name}/{blob_name}.tfstate/RESOURCE_NAME[?az_subscription_id=SUBSCRIPTION_ID]`
 
 Examples:
 
 - `ref+tfstateazurerm://my_rg/my_storage_account/terraform-backend/unique.terraform.tfstate/output.virtual_network.name`
+- `ref+tfstateazurerm://my_rg/my_storage_account/terraform-backend/unique.terraform.tfstate/output.virtual_network.name?az_subscription_id=abcd-efgh-ijlk-mnop`
 
 It allows to use Terraform state stored in Azure Blob storage given the resource group, storage account, container name and blob name. You can try to read the state with command:
 

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -13,14 +13,16 @@ import (
 )
 
 type provider struct {
-	backend    string
-	awsProfile string
+	backend          string
+	awsProfile       string
+	azSubscriptionId string
 }
 
 func New(cfg api.StaticConfig, backend string) *provider {
 	p := &provider{}
 	p.backend = backend
 	p.awsProfile = cfg.String("aws_profile")
+	p.azSubscriptionId = cfg.String("az_subscription_id")
 	return p
 }
 
@@ -70,6 +72,18 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 		}
 		defer func() {
 			_ = os.Setenv("AWS_PROFILE", v)
+		}()
+	}
+
+	// Allow setting the Subscription ID
+	if p.azSubscriptionId != "" {
+		v := os.Getenv("AZURE_SUBSCRIPTION_ID")
+		err := os.Setenv("AZURE_SUBSCRIPTION_ID", p.azSubscriptionId)
+		if err != nil {
+			return nil, fmt.Errorf("setting AZURE_SUBSCRIPTION_ID envvar: %w", err)
+		}
+		defer func() {
+			_ = os.Setenv("AZURE_SUBSCRIPTION_ID", v)
 		}()
 	}
 


### PR DESCRIPTION
Hello!

We have a scenario where TFState values are stored across multiple subscriptions. I imagine this will be the case for larger orgs that use DevTest subscriptions or central subscriptions.

This PR will allow users to specify the subscription ID but will still default to the current Azure contexts ID.

So the following will now be possible

```
fooenv: ref+tfstate://storageaccount/environment.tfstate/output.connection_string?az_subscription_id=devtest-subscription-id
foocentral: ref+tfstate://storageaccount/environment.tfstate/output.connection_string?az_subscription_id=central-subscription-id
foodefault: ref+tfstate://storageaccount/environment.tfstate/output.connection_string
```