### PR TITLE
Add -decode-kubernetes-secrets flag to vals eval

### DIFF
--- a/cmd/vals/main_test.go
+++ b/cmd/vals/main_test.go
@@ -40,3 +40,37 @@ kind: Secret
 		t.Errorf("unexpected out: expected=%s, got=%s", outExpected, outActual)
 	}
 }
+
+func TestKsEncode(t *testing.T) {
+	in := `stringData:
+  foo: FOO
+kind: Secret
+`
+	outExpected := `data:
+  foo: Rk9P
+kind: Secret
+`
+	var inNode yaml.Node
+	if err := yaml.Unmarshal([]byte(in), &inNode); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	outNode, err := KsEncode(inNode)
+	if err != nil {
+		t.Fatalf("ksdecode: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	encoder := yaml.NewEncoder(buf)
+	encoder.SetIndent(2)
+
+	if err := encoder.Encode(outNode); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	outActual := buf.String()
+
+	if outActual != outExpected {
+		t.Errorf("unexpected out: expected=%s, got=%s", outExpected, outActual)
+	}
+}

--- a/vals.go
+++ b/vals.go
@@ -549,8 +549,9 @@ func Exec(template map[string]interface{}, args []string, config ...ExecConfig) 
 }
 
 func EvalNodes(nodes []yaml.Node, c Options) ([]yaml.Node, error) {
-	var res []yaml.Node
+	var res []*yaml.Node
 	for _, node := range nodes {
+		node := node
 		var nodeValue map[string]interface{}
 		err := node.Decode(&nodeValue)
 		if err != nil {
@@ -564,10 +565,14 @@ func EvalNodes(nodes []yaml.Node, c Options) ([]yaml.Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, node)
+		res = append(res, &node)
 	}
-
-	return res, nil
+	return []yaml.Node{
+		{
+			Kind:    yaml.DocumentNode,
+			Content: res,
+		},
+	}, nil
 }
 
 func Eval(template map[string]interface{}, o ...Options) (map[string]interface{}, error) {


### PR DESCRIPTION
This PR embeds `vals ksdecode` into `vals eval` command.

See #131 as potential use-case.

Additional, the encode kubernetes secrets again. This is important, because `stringData` elements are always merged into `data` map on Kubernetes side. The downside here, that I'm unable to remove key from a secrets.

If there is a string with `{data: {a: "..", b: ".."}}` and I'm running `kubectl apply` with `{data: {a: ".."}}`, then the b property gets removed. However with `{strongData: {a: ".."}}` the b property will be still exists.

Tested with 

```bash
% kubectl create secret generic a --from-literal=a=ref+echo://foo/bar --dry-run=client -o yaml | ./bin/vals eval -kubernetes-secrets
```