### PR TITLE
Add support for assuming AWS IAM roles without AWS profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ Both provider have support for specifying AWS region and profile via envvars or 
 
 #### AWS SSM Parameter Store
 
-- `ref+awsssm://PATH/TO/PARAM[?region=REGION]`
-- `ref+awsssm://PREFIX/TO/PARAMS[?region=REGION&mode=MODE&version=VERSION]#/PATH/TO/PARAM`
+- `ref+awsssm://PATH/TO/PARAM[?region=REGION&role_arn=ASSUMED_ROLE_ARN]`
+- `ref+awsssm://PREFIX/TO/PARAMS[?region=REGION&role_arn=ASSUMED_ROLE_ARN&mode=MODE&version=VERSION]#/PATH/TO/PARAM`
 
 The first form result in a `GetParameter` call and result in the reference to be replaced with the value of the parameter.
 
@@ -290,9 +290,9 @@ On the other hand,
 
 #### AWS Secrets Manager
 
-- `ref+awssecrets://PATH/TO/SECRET[?region=REGION&version_stage=STAGE&version_id=ID]`
-- `ref+awssecrets://PATH/TO/SECRET[?region=REGION&version_stage=STAGE&version_id=ID]#/yaml_or_json_key/in/secret`
-- `ref+awssecrets://ACCOUNT:ARN:secret:/PATH/TO/PARAM[?region=REGION]`
+- `ref+awssecrets://PATH/TO/SECRET[?region=REGION&role_arn=ASSUMED_ROLE_ARN&version_stage=STAGE&version_id=ID]`
+- `ref+awssecrets://PATH/TO/SECRET[?region=REGION&role_arn=ASSUMED_ROLE_ARN&version_stage=STAGE&version_id=ID]#/yaml_or_json_key/in/secret`
+- `ref+awssecrets://ACCOUNT:ARN:secret:/PATH/TO/PARAM[?region=REGION&role_arn=ASSUMED_ROLE_ARN]`
 
 The third form allows you to reference a secret in another AWS account (if your cross-account secret permissions are configured).
 
@@ -305,8 +305,8 @@ Examples:
 
 #### AWS S3
 
-- `ref+s3://BUCKET/KEY/OF/OBJECT[?region=REGION&profile=AWS_PROFILE&version_id=ID]`
-- `ref+s3://BUCKET/KEY/OF/OBJECT[?region=REGION&profile=AWS_PROFILE&version_id=ID]#/yaml_or_json_key/in/secret`
+- `ref+s3://BUCKET/KEY/OF/OBJECT[?region=REGION&profile=AWS_PROFILE&role_arn=ASSUMED_ROLE_ARN&version_id=ID]`
+- `ref+s3://BUCKET/KEY/OF/OBJECT[?region=REGION&profile=AWS_PROFILE&role_arn=ASSUMED_ROLE_ARN&version_id=ID]#/yaml_or_json_key/in/secret`
 
 Examples:
 
@@ -318,8 +318,8 @@ Examples:
 
 #### AWS KMS
 
-- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE&alg=ENCRYPTION_ALGORITHM&key=KEY_ID&context=URL_ENCODED_JSON]`
-- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE&alg=ENCRYPTION_ALGORITHM&key=KEY_ID&context=URL_ENCODED_JSON]#/yaml_or_json_key/in/secret`
+- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE&role_arn=ASSUMED_ROLE_ARN&alg=ENCRYPTION_ALGORITHM&key=KEY_ID&context=URL_ENCODED_JSON]`
+- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE&role_arn=ASSUMED_ROLE_ARN&alg=ENCRYPTION_ALGORITHM&key=KEY_ID&context=URL_ENCODED_JSON]#/yaml_or_json_key/in/secret`
 
 Decrypts the URL-safe base64-encoded ciphertext using AWS KMS. Note that URL-safe base64 encoding is
 the same as "traditional" base64 encoding, except it uses `_` and `-` in place of `/` and `+`, respectively.

--- a/pkg/providers/awskms/awskms.go
+++ b/pkg/providers/awskms/awskms.go
@@ -15,13 +15,15 @@ type provider struct {
 	client *kms.KMS
 
 	// AWS KMS configuration
-	Region, Profile, KeyId, EncryptionAlgorithm, EncryptionContext string
+	Region, Profile, RoleARN                      string
+	KeyId, EncryptionAlgorithm, EncryptionContext string
 }
 
 func New(cfg api.StaticConfig) *provider {
 	p := &provider{}
 	p.Region = cfg.String("region")
 	p.Profile = cfg.String("profile")
+	p.RoleARN = cfg.String("role_arn")
 	p.KeyId = cfg.String("key")
 	p.EncryptionAlgorithm = cfg.String("alg")
 	p.EncryptionContext = cfg.String("context")
@@ -86,7 +88,7 @@ func (p *provider) getClient() *kms.KMS {
 		return p.client
 	}
 
-	sess := awsclicompat.NewSession(p.Region, p.Profile)
+	sess := awsclicompat.NewSession(p.Region, p.Profile, p.RoleARN)
 
 	p.client = kms.New(sess)
 	return p.client

--- a/pkg/providers/awssecrets/awssecrets.go
+++ b/pkg/providers/awssecrets/awssecrets.go
@@ -20,7 +20,8 @@ type provider struct {
 	log    *log.Logger
 
 	// AWS SecretsManager global configuration
-	Region, VersionStage, VersionId, Profile string
+	Region, Profile, RoleARN string
+	VersionStage, VersionId  string
 
 	Format string
 }
@@ -33,6 +34,7 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 	p.VersionStage = cfg.String("version_stage")
 	p.VersionId = cfg.String("version_id")
 	p.Profile = cfg.String("profile")
+	p.RoleARN = cfg.String("role_arn")
 	return p
 }
 
@@ -136,7 +138,7 @@ func (p *provider) getClient() *secretsmanager.SecretsManager {
 		return p.client
 	}
 
-	sess := awsclicompat.NewSession(p.Region, p.Profile)
+	sess := awsclicompat.NewSession(p.Region, p.Profile, p.RoleARN)
 
 	p.client = secretsmanager.New(sess)
 	return p.client

--- a/pkg/providers/s3/s3.go
+++ b/pkg/providers/s3/s3.go
@@ -24,6 +24,7 @@ type provider struct {
 	Region  string
 	Version string
 	Profile string
+	RoleARN string
 	Mode    string
 }
 
@@ -37,6 +38,7 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.Version = cfg.String("version_id")
 	}
 	p.Profile = cfg.String("profile")
+	p.RoleARN = cfg.String("role_arn")
 
 	return p
 }
@@ -92,7 +94,7 @@ func (p *provider) getS3Client() s3iface.S3API {
 		return p.s3Client
 	}
 
-	sess := awsclicompat.NewSession(p.Region, p.Profile)
+	sess := awsclicompat.NewSession(p.Region, p.Profile, p.RoleARN)
 
 	p.s3Client = s3.New(sess)
 	return p.s3Client

--- a/pkg/providers/ssm/ssm.go
+++ b/pkg/providers/ssm/ssm.go
@@ -25,6 +25,7 @@ type provider struct {
 	Region    string
 	Version   string
 	Profile   string
+	RoleARN   string
 	Mode      string
 	Recursive bool
 }
@@ -36,6 +37,7 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 	p.Region = cfg.String("region")
 	p.Version = cfg.String("version")
 	p.Profile = cfg.String("profile")
+	p.RoleARN = cfg.String("role_arn")
 	p.Mode = cfg.String("mode")
 	p.Recursive = cfg.String("recursive") == "true"
 
@@ -209,7 +211,7 @@ func (p *provider) getSSMClient() ssmiface.SSMAPI {
 		return p.ssmClient
 	}
 
-	sess := awsclicompat.NewSession(p.Region, p.Profile)
+	sess := awsclicompat.NewSession(p.Region, p.Profile, p.RoleARN)
 
 	p.ssmClient = ssm.New(sess)
 	return p.ssmClient

--- a/vals_awssecrets_test.go
+++ b/vals_awssecrets_test.go
@@ -13,7 +13,7 @@ import (
 
 // nolint
 func TestValues_AWSSecrets_String(t *testing.T) {
-	client := secretsmanager.New(awsclicompat.NewSession("", ""))
+	client := secretsmanager.New(awsclicompat.NewSession("ap-northeast-1", "", ""))
 
 	sec, err := client.CreateSecret(&secretsmanager.CreateSecretInput{
 		Name:         aws.String("/mykv/foo/mykey"),


### PR DESCRIPTION
This adds the support for assuming AWS IAM roles via vals ref URLs.

This is an important usability enhancement because we currently support assuming roles only by configuring AWS profiles before calling vals (and helmfile, which is a tool that integrates vals as a library).

In other words, you no longer need to configure AWS profiles to let vals assume role before reading e.g. AWS SSM Parameter Store. Instead, you just give a `role_arn` parameter in the vals ref URL query and vals assumes role for you.