### PR TITLE
fix: default ref regex should not include spaces and quotes when matching

### DIFF
--- a/pkg/expansion/expand_match.go
+++ b/pkg/expansion/expand_match.go
@@ -12,7 +12,7 @@ type ExpandRegexMatch struct {
 	Only   []string
 }
 
-var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*://[^\+\n]+)\+?`)
+var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*:\/\/[^\+\n "]+)\+?`)
 
 func (e *ExpandRegexMatch) InString(s string) (string, error) {
 	var sb strings.Builder

--- a/pkg/expansion/expand_match_test.go
+++ b/pkg/expansion/expand_match_test.go
@@ -103,6 +103,27 @@ func TestExpandRegexpMatchInString(t *testing.T) {
 			input:    "ref+vault://srv/foo/bar\n",
 			expected: "vault-srv-/foo/bar\n",
 		},
+		{
+			name:     "it should not match closing quotes when using query params",
+			regex:    DefaultRefRegexp,
+			only:     []string{"ref", "secretref"},
+			input:    "\"ref+awsssm://srv/foo/bar?mode=singleparam\"",
+			expected: "\"awsssm-srv-/foo/bar\"",
+		},
+		{
+			name:     "it should match greedily upto a space when using query params",
+			regex:    DefaultRefRegexp,
+			only:     []string{"ref", "secretref"},
+			input:    "ref+awsssm://srv/foo/bar?mode=singleparam some-string",
+			expected: "awsssm-srv-/foo/bar some-string",
+		},
+		{
+			name:     "it should handle multiple refs when using query params",
+			regex:    DefaultRefRegexp,
+			only:     []string{"ref", "secretref"},
+			input:    "ref+awsssm://srv/foo/bar?mode=singleparam some-string ref+awsssm://srv/foo/bar?mode=singleparam",
+			expected: "awsssm-srv-/foo/bar some-string awsssm-srv-/foo/bar",
+		},
 	}
 
 	for i := range testcases {


### PR DESCRIPTION
The current default ref regex expression matches closing quotes and incorrectly matches spaces when using query params, as seen [here](regexr.com/7i3jf)

The fix corrects the regex expression adds a space and a quote to the greedy match, which should fix the issues, as seen [here](regexr.com/7i3jo)

I added some test cases just to be sure