### PR TITLE
support AWS_ENDPOINT_URL configuration

### DIFF
--- a/pkg/awsclicompat/session.go
+++ b/pkg/awsclicompat/session.go
@@ -42,11 +42,25 @@ func NewSession(region string, profile string, roleARN string) *session.Session 
 // The fourth option of using FORCE_AWS_PROFILE=true and AWS_PROFILE=yourprofile is equivalent to `aws --profile ${AWS_PROFILE}`.
 // See https://github.com/helmfile/vals/issues/19#issuecomment-600437486 for more details and why and when this is needed.
 func newSesssion(region string, profile string) *session.Session {
-	var cfg *aws.Config
+	cfg := aws.NewConfig()
+
 	if region != "" {
-		cfg = aws.NewConfig().WithRegion(region)
-	} else {
-		cfg = aws.NewConfig()
+		cfg = cfg.WithRegion(region)
+	}
+
+	// AWS_ENDPOINT_URL
+	//
+	// Whenever AWS gets around to having their Golang libraries
+	// reach parity with their Python libraries and CLI, this
+	// workaround can go away. In the meantime, this level of
+	// configurability is useful for integrating with non-AWS
+	// infrastructure like Localstack and Moto for testing and
+	// development.
+	//
+	// https://github.com/aws/aws-sdk-go/issues/4942
+	endpointUrl := os.Getenv("AWS_ENDPOINT_URL")
+	if endpointUrl != "" {
+		cfg = cfg.WithEndpoint(endpointUrl)
 	}
 
 	opts := session.Options{


### PR DESCRIPTION
the AWS SDK and CLI (currently only in Python) allows for configuration of the AWS endpoint URL via the `AWS_ENDPOINT_URL` environment variable [1].

the Golang AWS SDK does not currently support this, but according to GitHub issues, parity is on the way [2].

this change allows for a temporary workaround (it took two years for this support to make it to the Python SDK [3]) that allows `vals` to pick up the `AWS_ENDPOINT_URL` environment variable and configure the session accordingly.

this allows for testing with non-AWS infrastructure like Localstack and Moto, and could even open the door for more comprehensive integration tests of the AWS functionality in this project without the need for using real AWS infrastructure.

[1]: https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html
[2]: https://github.com/aws/aws-sdk-go/issues/4942
[3]: https://github.com/boto/boto3/pull/2746