### PR TITLE
fix(providers): k8s, log message getting into stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ build:
 
 install: build
 	mv bin/vals ~/bin/
+
+lint:
+	golangci-lint run -v --out-format=github-actions

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports various backends including:
 - [Doppler](https://doppler.com/)
 - CredHub(Coming soon)
 - Pulumi State
-- Kubernetes secrets
+- Kubernetes
 
 - Use `vals eval -f refs.yaml` to replace all the `ref`s in the file to actual values and secrets.
 - Use `vals exec -f env.yaml -- <COMMAND>` to populate envvars and execute the command.
@@ -219,7 +219,7 @@ Please see the [relevant unit test cases](https://github.com/helmfile/vals/blob/
 - [1Password Connect](#1password-connect)
 - [Doppler](#doppler)
 - [Pulumi State](#pulumi-state)
-- [Kubernetes secrets](#kubernetes-secrets)
+- [Kubernetes](#kubernetes)
 
 Please see [pkg/providers](https://github.com/helmfile/vals/tree/master/pkg/providers) for the implementations of all the providers. The package names corresponds to the URI schemes.
 
@@ -724,9 +724,9 @@ Examples:
 - `ref+pulumistateapi://aws-native_s3_Bucket/my-bucket/outputs/tags.%23(key==SomeKey).value?project=my-project&stack=my-stack`
 - `ref+pulumistateapi://kubernetes_storage.k8s.io__v1_StorageClass/gp2-encrypted/inputs/metadata.name?project=my-project&stack=my-stack`
 
-### Kubernetes secrets
+### Kubernetes
 
-Fetch value from a Kubernetes secret:
+Fetch value from a Kubernetes:
 
 - `ref+k8s://API_VERSION/KIND/NAMESPACE/NAME/KEY[?kubeConfigPath=<path_to_kubeconfig>&kubeContext=<kubernetes context name>]`
 

--- a/pkg/providers/k8s/k8s.go
+++ b/pkg/providers/k8s/k8s.go
@@ -33,11 +33,7 @@ func New(l *log.Logger, cfg api.StaticConfig) (*provider) {
 		return nil
 	}
 
-	p.KubeContext, err = getKubeContext(cfg)
-	if err != nil {
-		p.log.Debugf("vals-k8s: Unable to get a valid kubeContext: %s", err)
-		return nil
-	}
+	p.KubeContext = getKubeContext(cfg)
 
 	if p.KubeContext == "" {
 		p.log.Debugf("vals-k8s: kubeContext was not provided. Using current context.")
@@ -120,12 +116,11 @@ func (p *provider) GetStringMap(path string) (map[string]interface{}, error) {
 }
 
 // Return an empty Kube context if none is provided
-//nolint:unparam // TODO: https://github.com/mvdan/unparam/issues/40
-func getKubeContext(cfg api.StaticConfig) (string, error) {
+func getKubeContext(cfg api.StaticConfig) string {
 	if cfg.String("kubeContext") != "" {
-		return cfg.String("kubeContext"), nil
+		return cfg.String("kubeContext")
 	}
-	return "", nil
+	return ""
 }
 
 // Build the client-go config using a specific context

--- a/pkg/providers/k8s/k8s.go
+++ b/pkg/providers/k8s/k8s.go
@@ -21,7 +21,7 @@ type provider struct {
 	KubeContext    string
 }
 
-func New(l *log.Logger, cfg api.StaticConfig) (*provider) {
+func New(l *log.Logger, cfg api.StaticConfig) *provider {
 	p := &provider{
 		log: l,
 	}

--- a/pkg/providers/k8s/k8s_test.go
+++ b/pkg/providers/k8s/k8s_test.go
@@ -136,7 +136,7 @@ func Test_getObject(t *testing.T) {
 	}
 }
 
-func Test_getKubeConfig(t *testing.T) {
+func Test_getKubeConfigPath(t *testing.T) {
 	homeDir, _ := os.UserHomeDir()
 	testcases := []struct {
 		config           config.MapConfig
@@ -198,7 +198,7 @@ func Test_getKubeConfig(t *testing.T) {
 			if tc.kubeConfigEnvVar != "" {
 				os.Setenv("KUBECONFIG", tc.kubeConfigEnvVar)
 			}
-			got, err := getKubeConfig(tc.config)
+			got, err := getKubeConfigPath(tc.config)
 			if err != nil {
 				if err.Error() != tc.wantErr {
 					t.Fatalf("unexpected error: want %q, got %q", tc.wantErr, err.Error())
@@ -242,7 +242,10 @@ func Test_getKubeContext(t *testing.T) {
 	for i := range testcases {
 		tc := testcases[i]
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			got := getKubeContext(tc.config)
+			got, err := getKubeContext(tc.config)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result: -(want), +(got)\n%s", diff)
 			}
@@ -337,7 +340,7 @@ func Test_GetString(t *testing.T) {
 			conf := map[string]interface{}{}
 			conf["kubeConfigPath"] = fmt.Sprintf("%s/.kube/config", homeDir)
 			conf["kubeContext"] = "minikube"
-			p, _ := New(logger, config.MapConfig{M: conf})
+			p := New(logger, config.MapConfig{M: conf})
 
 			got, err := p.GetString(tc.path)
 			if err != nil {

--- a/pkg/providers/k8s/k8s_test.go
+++ b/pkg/providers/k8s/k8s_test.go
@@ -242,10 +242,7 @@ func Test_getKubeContext(t *testing.T) {
 	for i := range testcases {
 		tc := testcases[i]
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			got, err := getKubeContext(tc.config)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
+			got := getKubeContext(tc.config)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result: -(want), +(got)\n%s", diff)
 			}

--- a/pkg/stringmapprovider/stringmapprovider.go
+++ b/pkg/stringmapprovider/stringmapprovider.go
@@ -45,7 +45,7 @@ func New(l *log.Logger, provider api.StaticConfig) (api.LazyLoadedStringMapProvi
 	case "gkms":
 		return gkms.New(l, provider), nil
 	case "k8s":
-		return k8s.New(l, provider)
+		return k8s.New(l, provider), nil
 	}
 
 	return nil, fmt.Errorf("failed initializing string-map provider from config: %v", provider)

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -66,7 +66,7 @@ func New(l *log.Logger, provider api.StaticConfig) (api.LazyLoadedStringProvider
 	case "gkms":
 		return gkms.New(l, provider), nil
 	case "k8s":
-		return k8s.New(l, provider)
+		return k8s.New(l, provider), nil
 	}
 
 	return nil, fmt.Errorf("failed initializing string provider from config: %v", provider)

--- a/vals.go
+++ b/vals.go
@@ -251,7 +251,8 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 			p := gkms.New(r.logger, conf)
 			return p, nil
 		case ProviderK8s:
-			return k8s.New(r.logger, conf)
+			p := k8s.New(r.logger, conf)
+			return p, nil
 		}
 		return nil, fmt.Errorf("no provider registered for scheme %q", scheme)
 	}


### PR DESCRIPTION
### Major Issue

A simple `vals get ref+k8s://... > result.txt` results in logs (`stderr`) mixing with result (`stdout`).

### Changes

- fix: remove `fmt.Printf` (-> `p.log.Debugf`) **PRINCIPAL**
- docs: header `Kubernetes secrets` -> `Kubernetes` (because of ConfigMap) 
- refactor: keep `return p, nil` `return k8s.New(l, provider), nil` patterns
- refactor: `return result, err` in some (unparam lint forbids all) custom functions
- feat: add `make lint`
