### PR TITLE
Load all common k8s auth providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/DopplerHQ/cli v0.5.11-0.20230908185655-7aef4713e1a4
 	github.com/a8m/envsubst v1.3.0
 	github.com/aws/aws-sdk-go v1.43.43
+	github.com/cyberark/conjur-api-go v0.11.1
 	github.com/fujiwara/tfstate-lookup v1.1.5
 	github.com/getsops/sops/v3 v3.8.0
 	github.com/google/go-cmp v0.5.9
@@ -76,7 +77,6 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/cyberark/conjur-api-go v0.11.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/pkg/providers/k8s/k8s.go
+++ b/pkg/providers/k8s/k8s.go
@@ -8,6 +8,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 


### PR DESCRIPTION
Attempting to use vals (via helmfile) today, I ran into an error:

    ...Unable to get Secret ci-runners/runner-cos-cache-keys: Unable to
    create the Kubernetes client: no Auth Provider found for name "oidc"

A quick search showed that the solution is to ensure the auth plugins are imported; testing this change locally with a rebuilt helmfile made my auth problems go away.