### PR TITLE
feat(gcpsecrets): add trim_nl parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Examples:
 
 - `ref+gcpsecrets://PROJECT/SECRET[?version=VERSION]`
 - `ref+gcpsecrets://PROJECT/SECRET[?version=VERSION]#/yaml_or_json_key/in/secret`
+- `ref+gcpsecrets://PROJECT/SECRET[?version=VERSION][&fallback=valuewhenkeyisnotfound][&optional=true][&trim_nl=true]#/yaml_or_json_key/in/secret`
 
 Examples:
 

--- a/vals_gcpsecrets_test.go
+++ b/vals_gcpsecrets_test.go
@@ -148,6 +148,23 @@ func TestValues_GCPSecretsManager(t *testing.T) {
 				},
 			},
 		},
+		{
+			"trim_nl string",
+			map[string]string{"valstestvar": "foo: bar\n"},
+			map[string]interface{}{
+				"provider": map[string]interface{}{
+					"name":    "gcpsecrets",
+					"version": "latest",
+					"type":    "string",
+					"path":    projectId,
+					"trim_nl": true,
+				},
+				"inline": map[string]interface{}{
+					"valstestvar": "valstestvar",
+				},
+			},
+			map[string]interface{}{"valstestvar": "foo: bar"},
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
As seen in https://cloud.google.com/sdk/gcloud/reference/beta/secrets/create, `gcloud secrets create` adds a LF character to the end of the secret value. This is tracked by https://issuetracker.google.com/issues/157867791 for 4 years now. 
This new `trim_nl` parameter removes LFs at the end of the secret value. Default behavior is unchanged.

```shell
$ echo 'secret: "ref+gcpsecrets://project/secret+"' | vals eval -f - -o json 
{"secret":"mysecret\n"}
$ echo 'secret: "ref+gcpsecrets://project/secret?trim_nl=false+"' | vals eval -f - -o json 
{"secret":"mysecret\n"}
$ echo 'secret: "ref+gcpsecrets://project/secret?trim_nl=true+"' | vals eval -f - -o json 
{"secret":"mysecret"}
```
