### PR TITLE
feat: make vals able to eval dictionaries

### DIFF
--- a/vals_test.go
+++ b/vals_test.go
@@ -116,3 +116,36 @@ kind: Secret
 
 	require.Equal(t, expected, buf.String())
 }
+
+func TestEvalNodesWithDictionaries(t *testing.T) {
+  var yamlDocs = `- entry: first
+  username: ref+echo://secrets.enc.yaml
+- entry: second
+  username: ref+echo://secrets.enc.yaml
+`
+
+  var expected = `- entry: first
+  username: secrets.enc.yaml
+- entry: second
+  username: secrets.enc.yaml
+`
+
+	tmpFile, err := os.CreateTemp("", "secrets.yaml")
+	defer os.Remove(tmpFile.Name())
+	require.NoError(t, err)
+
+	_, err = tmpFile.WriteString(yamlDocs)
+	require.NoError(t, err)
+
+	input, err := Inputs(tmpFile.Name())
+	require.NoError(t, err)
+
+	nodes, err := EvalNodes(input, Options{})
+	require.NoError(t, err)
+	buf := new(strings.Builder)
+
+	err = Output(buf, "", nodes)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, buf.String())
+}


### PR DESCRIPTION
We've some use cases where we have plain dictionaries in yaml files and need to evaluate secret refs with vals. We've a workaround/hack to use yq to change this dictionaries into a format that vals likes and then back to it's origin after secrets are evaluated. But this is kinda hacky, thus this PR.

The yq hack (don't mind the extra quotings/escapes as this is part of a larger script):

```sh
 yq ". as \$in | {\"data\": \$in} | .data = (eval(.) | .data)" "$file" | vals eval | yq eval ".data" > "${file}.tmp" && mv "${file}.tmp" "$file"
```
