### PR TITLE
docs: Add more info link to README for authentication methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,8 @@ The order in which authentication methods are checked is:
 3. Username/Password
 4. Azure CLI or Managed identity (set environment `AZURE_USE_MSI=true` to enabled MSI)
 
+more see: https://github.com/helmfile/vals/issues/441
+
 ### EnvSubst
 
 Environment variables substitution.


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change adds a reference link for further information on authentication methods.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R661-R662): Added a link to a GitHub issue for more details on authentication methods.

fix: https://github.com/helmfile/vals/issues/441