### PR TITLE
refactor(ci): Simplify CI workflow by removing unit-test job

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -28,4 +28,4 @@ jobs:
         go-version-file: 'go.mod'
         cache: true
     - name: test
-      run: kubectl cluster-info 
+      run: make test

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,31 @@
+name: E2E test 
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_TESTS: true 
+    steps:
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1.12.0
+      with:
+        cluster_name: cluster
+    - name: Set k8s provider
+      run: |
+        kubectl create namespace test-namespace
+        kubectl create secret generic mysecret -n test-namespace --from-literal=key=p4ssw0rd
+        kubectl create configmap myconfigmap -n test-namespace --from-literal=key=configValue
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+    - name: test
+      run: kubectl cluster-info 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -19,4 +19,4 @@ jobs:
         go-version-file: 'go.mod'
         cache: true
     - name: test
-      run: make test
+      run: echo "unit test" 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,4 +1,4 @@
-name: CI 
+name: Unit Test
 
 on:
   push:
@@ -7,8 +7,12 @@ on:
     branches: [ main ]
 
 jobs:
-  build-test:
+  unit-test:
+    env:
+      SKIP_TESTS: true 
     runs-on: ubuntu-latest
+    env:
+      SKIP_TESTS: true 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go
@@ -16,5 +20,5 @@ jobs:
       with:
         go-version-file: 'go.mod'
         cache: true
-    - name: build 
-      run: make build
+    - name: test
+      run: make test

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   unit-test:
-    env:
-      SKIP_TESTS: true 
     runs-on: ubuntu-latest
     env:
       SKIP_TESTS: true 


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflows to better organize and separate concerns between different types of tests. The changes include renaming and restructuring the CI workflow, as well as creating separate workflows for unit tests and end-to-end (E2E) tests.

Changes to GitHub Actions workflows:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL1-R1): Renamed the workflow from "Go" to "CI" and removed the unit-test job to streamline the CI process. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL1-R1) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL10) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL22-L44)
* [`.github/workflows/e2e-test.yaml`](diffhunk://#diff-2154d5cafbed57574ae09e3c4689fb9aa37e3472f599d6a27c00e5564149f4e6R1-R31): Added a new workflow for E2E tests, which includes setting up a Kubernetes Kind cluster and running cluster-info tests.
* [`.github/workflows/unit-test.yaml`](diffhunk://#diff-edd3f9143a1e45f2d467ef587fb552951b85c4fe2d26211b9db0d46b1219495bR1-R24): Added a new workflow for unit tests, which includes setting up the Go environment and running the tests.