### PR TITLE
feat: handle timestamps as strings in YAML parsing

### DIFF
--- a/vals_test.go
+++ b/vals_test.go
@@ -149,3 +149,37 @@ func TestEvalNodesWithDictionaries(t *testing.T) {
 
 	require.Equal(t, expected, buf.String())
 }
+
+func TestEvalNodesWithTime(t *testing.T) {
+	var yamlDocs = `
+date: 2025-01-01
+datetime: 2025-01-01T12:34:56Z
+datetime_millis: 2025-01-01T12:34:56.789Z
+datetime_offset: 2025-01-01T12:34:56+01:00
+`
+
+	var expected = `date: "2025-01-01"
+datetime: "2025-01-01T12:34:56Z"
+datetime_millis: "2025-01-01T12:34:56.789Z"
+datetime_offset: "2025-01-01T12:34:56+01:00"
+`
+
+	tmpFile, err := os.CreateTemp("", "secrets.yaml")
+	defer os.Remove(tmpFile.Name())
+	require.NoError(t, err)
+
+	_, err = tmpFile.WriteString(yamlDocs)
+	require.NoError(t, err)
+
+	input, err := Inputs(tmpFile.Name())
+	require.NoError(t, err)
+
+	nodes, err := EvalNodes(input, Options{})
+	require.NoError(t, err)
+	buf := new(strings.Builder)
+
+	err = Output(buf, "", nodes)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, buf.String())
+}


### PR DESCRIPTION
see: https://github.com/go-yaml/yaml/issues/770

This pull request introduces a new function to handle YAML timestamp parsing and includes a corresponding test to ensure its proper functionality. The most important changes include the addition of the `replaceTimestamp` function and a new test case for evaluating nodes with timestamps.

YAML timestamp handling:

* [`io.go`](diffhunk://#diff-2538bb8c5daf4057de32a936a59f125087b9bb7d0b2832b33e9743456e2a1ea3R73-R98): Added the `replaceTimestamp` function to treat timestamps as strings to avoid incorrect encoding of "YYYY-MM-DD" formats.

Testing:

* [`vals_test.go`](diffhunk://#diff-7ccbe6d5d8a057b65566e71a531774c01d4c1e719a02a133a216e847287b7f5fR152-R185): Added `TestEvalNodesWithTime` to verify that YAML timestamps are correctly treated as strings during evaluation.