### PR TITLE
feat: enhance timestamp handling in YAML parsing to support sequences

### DIFF
--- a/io.go
+++ b/io.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -87,7 +88,7 @@ func replaceTimestamp(n *yaml.Node) {
 		return
 	}
 	for _, innerNode := range n.Content {
-		if innerNode.Tag == "!!map" {
+		if slices.Contains([]string{"!!map", "!!seq"}, innerNode.Tag) {
 			replaceTimestamp(innerNode)
 		}
 		if innerNode.Tag == "!!timestamp" {

--- a/vals_test.go
+++ b/vals_test.go
@@ -153,12 +153,16 @@ func TestEvalNodesWithDictionaries(t *testing.T) {
 func TestEvalNodesWithTime(t *testing.T) {
 	var yamlDocs = `
 date: 2025-01-01
+datet_in_list: 
+  - from: 2025-01-01
 datetime: 2025-01-01T12:34:56Z
 datetime_millis: 2025-01-01T12:34:56.789Z
 datetime_offset: 2025-01-01T12:34:56+01:00
 `
 
 	var expected = `date: "2025-01-01"
+datet_in_list:
+  - from: "2025-01-01"
 datetime: "2025-01-01T12:34:56Z"
 datetime_millis: "2025-01-01T12:34:56.789Z"
 datetime_offset: "2025-01-01T12:34:56+01:00"


### PR DESCRIPTION
This pull request includes changes to the `io.go` and `vals_test.go` files to improve the handling of YAML nodes and timestamps. The most important changes include adding the `slices` package, updating the `replaceTimestamp` function, and modifying test cases to include dates in lists.

Improvements to YAML node handling:

* [`io.go`](diffhunk://#diff-2538bb8c5daf4057de32a936a59f125087b9bb7d0b2832b33e9743456e2a1ea3R10): Added the `slices` package to the import list.
* [`io.go`](diffhunk://#diff-2538bb8c5daf4057de32a936a59f125087b9bb7d0b2832b33e9743456e2a1ea3L90-R91): Updated the `replaceTimestamp` function to use `slices.Contains` for checking tags, allowing it to handle both `!!map` and `!!seq` tags.

Enhancements to test cases:

* [`vals_test.go`](diffhunk://#diff-7ccbe6d5d8a057b65566e71a531774c01d4c1e719a02a133a216e847287b7f5fR156-R165): Modified the `TestEvalNodesWithTime` function to include dates in lists for better coverage of date handling.