### PR TITLE
Add OCI support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/hashicorp/vault/api v1.21.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/yandex-cloud/go-genproto v0.24.0
@@ -34,6 +35,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
+	oras.land/oras-go/v2 v2.6.0
 )
 
 require (
@@ -73,6 +75,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,8 @@ k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOP
 k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/pkg/providers/oci/oci.go
+++ b/pkg/providers/oci/oci.go
@@ -1,0 +1,182 @@
+package oci
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"gopkg.in/yaml.v3"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+	"oras.land/oras-go/v2/registry/remote/retry"
+
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+)
+
+type provider struct {
+	// Keeping track of repository
+	ctx        context.Context
+	creds      *credentials.DynamicStore
+	repository *remote.Repository
+	log        *log.Logger
+
+	// Annotation to match for layer, org.opencontainers.image.title by default
+	Annotation string
+}
+
+func New(l *log.Logger, cfg api.StaticConfig) *provider {
+	p := &provider{
+		log: l,
+	}
+	p.Annotation = cfg.String("annotation")
+	if p.Annotation == "" {
+		p.Annotation = "org.opencontainers.image.title"
+	}
+	creds, err := credentials.NewStoreFromDocker(credentials.StoreOptions{})
+	if err != nil {
+		p.log.Debugf("Failed to load Docker credentials: %v\n", err)
+	}
+	p.creds = creds
+	return p
+}
+
+// expected format repository:TAG:org.opencontainers.image.title
+func (p *provider) GetString(key string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	p.ctx = ctx
+
+	// Parse the key using the global function
+	registryRepo, tagDigest, filename, err := parseKey(key)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = p.configureRepo(registryRepo)
+	if err != nil {
+		return "", fmt.Errorf("unable to configure repository: %w", err)
+	}
+
+	manifest, err := p.getManifest(tagDigest)
+	if err != nil {
+		return "", fmt.Errorf("unable to get manifest from repo: %w", err)
+	}
+
+	str, err := p.getLayerByAnnotationFromManifest(manifest, filename)
+	if err != nil {
+		return "", err
+	}
+
+	return str, nil
+}
+
+func (p *provider) GetStringMap(key string) (map[string]any, error) {
+	yamlData, err := p.GetString(key)
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[string]any{}
+
+	if err := yaml.Unmarshal([]byte(yamlData), &m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (p *provider) configureRepo(repoString string) (registry.Repository, error) {
+	repository, err := remote.NewRepository(repoString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repo: %w", err)
+	}
+	repository.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+		Credential: func(ctx context.Context, registry string) (auth.Credential, error) {
+			return p.creds.Get(ctx, registry)
+		},
+	}
+	p.repository = repository
+	return repository, nil
+}
+
+func (p *provider) getManifest(tagDigest string) (m *v1.Manifest, err error) {
+	desc, reader, err := p.repository.FetchReference(p.ctx, tagDigest)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch reference from repository: %v", err)
+	}
+	defer func() {
+		if cerr := reader.Close(); err == nil {
+			err = cerr
+		}
+	}()
+	p.log.Debugf("Found desc: %+v and read: %v", desc, reader)
+
+	var manifestContent []byte
+	manifestContent, err = io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("err reading content: %v", err)
+	}
+
+	p.log.Debugf("Parsed manifest content: %s", manifestContent)
+	var manifest v1.Manifest
+	if err = json.Unmarshal(manifestContent, &manifest); err != nil {
+		panic(err)
+	}
+	return &manifest, nil
+}
+
+func (p *provider) getLayerByAnnotationFromManifest(manifest *v1.Manifest, filename string) (string, error) {
+	for _, layer := range manifest.Layers {
+		if layer.Annotations[p.Annotation] == filename {
+			layerContent, err := content.FetchAll(p.ctx, p.repository, layer)
+			if err != nil {
+				return "", fmt.Errorf("unable to fetch layer from repo: %w", err)
+			}
+			return string(layerContent), nil
+		}
+	}
+	return "", fmt.Errorf("unable to find layer with matching annotation: %s", p.Annotation)
+}
+
+// ParseKey parses an OCI key in the format "registry/repository:tag:filename"
+// It tries different colon positions from right to left until a valid reference is found
+func parseKey(key string) (registryRepo, tagDigest, filename string, err error) {
+	// Start from the rightmost colon and work backwards
+	remaining := key
+	var filenameParts []string
+	for {
+		// Find the last colon in the remaining string
+		lastColon := strings.LastIndex(remaining, ":")
+		if lastColon == -1 {
+			return "", "", "", fmt.Errorf("invalid key format, expected registry/repository:tag:filename got: %s", key)
+		}
+
+		// Split at this colon
+		imageRef := remaining[:lastColon]
+		filenameParts = append([]string{remaining[lastColon+1:]}, filenameParts...)
+
+		// Try to parse this as a valid image reference
+		ref, err := registry.ParseReference(imageRef)
+		if err == nil {
+			registryRepo = ref.Registry + "/" + ref.Repository
+			return registryRepo, ref.Reference, strings.Join(filenameParts, ":"), nil
+		}
+
+		remaining = imageRef
+
+		// If there are no more colons to try, return error
+		if !strings.Contains(remaining, ":") {
+			return "", "", "", fmt.Errorf("invalid key format, expected registry/repository:tag:filename got: %s", key)
+		}
+	}
+}

--- a/pkg/providers/oci/oci_test.go
+++ b/pkg/providers/oci/oci_test.go
@@ -1,0 +1,442 @@
+package oci
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         api.StaticConfig
+		wantAnnotation string
+	}{
+		{
+			name:           "default annotation",
+			config:         config.MapConfig{M: map[string]any{}},
+			wantAnnotation: "org.opencontainers.image.title",
+		},
+		{
+			name:           "custom annotation",
+			config:         config.MapConfig{M: map[string]any{"annotation": "custom.annotation"}},
+			wantAnnotation: "custom.annotation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.Config{Output: os.Stderr})
+			p := New(logger, tt.config)
+
+			if p == nil {
+				t.Fatal("New() returned nil provider")
+			}
+
+			if p.log != logger {
+				t.Error("logger not set correctly")
+			}
+
+			if p.Annotation != tt.wantAnnotation {
+				t.Errorf("annotation = %v, want %v", p.Annotation, tt.wantAnnotation)
+			}
+
+			if p.creds == nil {
+				t.Error("credentials not initialized")
+			}
+		})
+	}
+}
+
+func TestProvider_GetString(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{
+			name:    "invalid key format - not enough parts",
+			key:     "repo:tag",
+			wantErr: true,
+		},
+		{
+			name:    "invalid key format - empty parts",
+			key:     ":::",
+			wantErr: true,
+		},
+		{
+			name:    "valid key format",
+			key:     "registry.example.com/repo:v1.0.0:config.yaml",
+			wantErr: true, // Will fail due to network/repo not existing
+		},
+		{
+			name:    "valid key format with multiple slashes",
+			key:     "registry.example.com/repo/repo:v1.0.0:config.yaml",
+			wantErr: true, // Will fail due to network/repo not existing
+		},
+		// TODO need to fix this
+		// {
+		// 	name:    "valid key format with port",
+		// 	key:     "registry.example.com:1234/repo:v1.0.0:config.yaml",
+		// 	wantErr: false, // Will fail due to network/repo not existing
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.Config{Output: os.Stderr})
+			p := New(logger, config.MapConfig{M: map[string]any{}})
+
+			var err error
+			var panicOccurred bool
+
+			// Handle potential panic for invalid key formats
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						panicOccurred = true
+					}
+				}()
+				_, err = p.GetString(tt.key)
+			}()
+
+			if tt.wantErr && err == nil && !panicOccurred {
+				t.Error("expected error but got none")
+			}
+
+			if !tt.wantErr && (err != nil || panicOccurred) {
+				// Debug: unwrap and show all error types
+				if err != nil {
+					t.Logf("Error chain:")
+					currentErr := err
+					for i := 0; currentErr != nil; i++ {
+						t.Logf("  [%d] Type: %T, Value: %v", i, currentErr, currentErr)
+						if unwrapped := errors.Unwrap(currentErr); unwrapped != nil {
+							currentErr = unwrapped
+						} else {
+							break
+						}
+					}
+				}
+				if panicOccurred {
+					t.Logf("Panic occurred during execution")
+				}
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestProvider_GetStringMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{
+			name:    "invalid key",
+			key:     "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.Config{Output: os.Stderr})
+			p := New(logger, config.MapConfig{M: map[string]any{}})
+
+			result, err := p.GetStringMap(tt.key)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.wantErr && result == nil {
+				t.Error("expected non-nil result")
+			}
+		})
+	}
+}
+
+func TestProvider_GetStringMap_ValidYAML(t *testing.T) {
+	// Test YAML parsing directly by creating a mock provider
+	validYAML := `
+key1: value1
+key2: 
+  nested: value2
+key3: 123
+`
+
+	// We can't easily mock the full OCI flow, so we'll test the YAML parsing logic
+	// by using the unmarshal part of GetStringMap indirectly
+	testProvider := &mockProvider{yaml: validYAML}
+	result, err := testProvider.GetStringMap("test:key")
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expected := map[string]any{
+		"key1": "value1",
+		"key2": map[string]any{"nested": "value2"},
+		"key3": 123,
+	}
+
+	if len(result) != len(expected) {
+		t.Errorf("expected %d keys, got %d", len(expected), len(result))
+	}
+
+	if result["key1"] != expected["key1"] {
+		t.Errorf("key1: expected %v, got %v", expected["key1"], result["key1"])
+	}
+
+	if result["key3"] != expected["key3"] {
+		t.Errorf("key3: expected %v, got %v", expected["key3"], result["key3"])
+	}
+}
+
+func TestProvider_GetStringMap_InvalidYAML(t *testing.T) {
+	invalidYAML := `
+key1: value1
+key2: [
+  - invalid
+`
+
+	testProvider := &mockProvider{yaml: invalidYAML}
+	_, err := testProvider.GetStringMap("test:key")
+
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestProvider_configureRepo(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoStr string
+		wantErr bool
+	}{
+		{
+			name:    "valid repository string",
+			repoStr: "registry.example.com/repo",
+			wantErr: false,
+		},
+		{
+			name:    "empty repository string",
+			repoStr: "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.Config{Output: os.Stderr})
+			p := New(logger, config.MapConfig{M: map[string]any{}})
+
+			repo, err := p.configureRepo(tt.repoStr)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.wantErr && repo == nil {
+				t.Error("expected non-nil repository")
+			}
+
+			if !tt.wantErr && p.repository == nil {
+				t.Error("expected provider repository to be set")
+			}
+		})
+	}
+}
+
+func TestProvider_getLayerByTitleFromManifest(t *testing.T) {
+	tests := []struct {
+		manifest    *v1.Manifest
+		name        string
+		filename    string
+		annotation  string
+		expectedErr string
+		wantErr     bool
+	}{
+		{
+			name: "layer not found",
+			manifest: &v1.Manifest{
+				Layers: []v1.Descriptor{
+					{
+						Annotations: map[string]string{
+							"org.opencontainers.image.title": "other.yaml",
+						},
+					},
+				},
+			},
+			filename:    "config.yaml",
+			annotation:  "org.opencontainers.image.title",
+			wantErr:     true,
+			expectedErr: "unable to find layer with matching annotation",
+		},
+		{
+			name: "empty manifest",
+			manifest: &v1.Manifest{
+				Layers: []v1.Descriptor{},
+			},
+			filename:    "config.yaml",
+			annotation:  "org.opencontainers.image.title",
+			wantErr:     true,
+			expectedErr: "unable to find layer with matching annotation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.Config{Output: os.Stderr})
+			p := New(logger, config.MapConfig{M: map[string]any{}})
+			p.Annotation = tt.annotation
+
+			// This will fail due to network/repository not being set up
+			_, err := p.getLayerByAnnotationFromManifest(tt.manifest, tt.filename)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if tt.expectedErr != "" && (err == nil || !strings.Contains(err.Error(), tt.expectedErr)) {
+				t.Errorf("expected error containing %q, got %v", tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestKeyParsing(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		wantRepo  string
+		wantRef   string
+		wantTitle string
+		wantError bool
+	}{
+		{
+			name:      "valid key",
+			key:       "registry.example.com/repo:v1.0.0:config.yaml",
+			wantRepo:  "registry.example.com/repo",
+			wantRef:   "v1.0.0",
+			wantTitle: "config.yaml",
+			wantError: false,
+		},
+		{
+			name:      "key with colons in repository name",
+			key:       "registry.example.com:1234/repo:v1.0.0:config.yaml",
+			wantRepo:  "registry.example.com:1234/repo",
+			wantRef:   "v1.0.0",
+			wantTitle: "config.yaml",
+			wantError: false,
+		},
+		{
+			name:      "key with colons in filename",
+			key:       "registry.example.com/repo:v1.0.0:namespace:config.yaml",
+			wantRepo:  "registry.example.com/repo",
+			wantRef:   "v1.0.0",
+			wantTitle: "namespace:config.yaml",
+			wantError: false,
+		},
+		{
+			name:      "key with colons in filename and repository port",
+			key:       "registry.example.com:1234/repo:v1.0.0:namespace:config.yaml",
+			wantRepo:  "registry.example.com:1234/repo",
+			wantRef:   "v1.0.0",
+			wantTitle: "namespace:config.yaml",
+			wantError: false,
+		},
+		{
+			name:      "key with missing title",
+			key:       "registry.example.com/repo@sha256:a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+			wantRepo:  "registry.example.com:1234/repo",
+			wantRef:   "sha256:a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+			wantTitle: "",
+			wantError: true,
+		},
+		{
+			name:      "key with repository port and digest",
+			key:       "registry.example.com:1234/repo@sha256:a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456:config.yaml",
+			wantRepo:  "registry.example.com:1234/repo",
+			wantRef:   "sha256:a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+			wantTitle: "config.yaml",
+			wantError: false,
+		},
+		{
+			name:      "key with digest and colons",
+			key:       "registry.example.com:1234/repo@sha256:a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456:namespace:config.yaml",
+			wantRepo:  "registry.example.com:1234/repo",
+			wantRef:   "sha256:a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+			wantTitle: "namespace:config.yaml",
+			wantError: false,
+		},
+		{
+			name:      "insufficient parts",
+			key:       "repo:tag",
+			wantError: true,
+		},
+		{
+			name:      "empty parts",
+			key:       ":::",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, ref, title, err := parseKey(tt.key)
+
+			if tt.wantError && err == nil {
+				t.Error("expected parsing to fail but it succeeded")
+				return
+			} else if !tt.wantError && err != nil {
+				t.Error("expected parsing to succeed but it failed", err)
+				return
+			} else if tt.wantError && err != nil {
+				return
+			}
+
+			if repo != tt.wantRepo {
+				t.Errorf("repo = %v, want %v", repo, tt.wantRepo)
+			}
+			if ref != tt.wantRef {
+				t.Errorf("ref = %v, want %v", ref, tt.wantRef)
+			}
+			if title != tt.wantTitle {
+				t.Errorf("title = %v, want %v", title, tt.wantTitle)
+			}
+		})
+	}
+}
+
+type mockProvider struct {
+	yaml string
+}
+
+func (m *mockProvider) GetStringMap(key string) (map[string]any, error) {
+	result := map[string]any{}
+
+	if err := yaml.Unmarshal([]byte(m.yaml), &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/helmfile/vals/pkg/providers/hcpvaultsecrets"
 	"github.com/helmfile/vals/pkg/providers/httpjson"
 	"github.com/helmfile/vals/pkg/providers/k8s"
+	"github.com/helmfile/vals/pkg/providers/oci"
 	"github.com/helmfile/vals/pkg/providers/onepassword"
 	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
 	"github.com/helmfile/vals/pkg/providers/pulumi"
@@ -61,6 +62,8 @@ func New(l *log.Logger, provider api.StaticConfig) (api.LazyLoadedStringProvider
 		return azurekeyvault.New(provider), nil
 	case "gitlab":
 		return gitlab.New(provider), nil
+	case "oci":
+		return oci.New(l, provider), nil
 	case "onepassword":
 		return onepassword.New(provider), nil
 	case "onepasswordconnect":

--- a/vals.go
+++ b/vals.go
@@ -38,6 +38,7 @@ import (
 	"github.com/helmfile/vals/pkg/providers/httpjson"
 	"github.com/helmfile/vals/pkg/providers/k8s"
 	"github.com/helmfile/vals/pkg/providers/keychain"
+	"github.com/helmfile/vals/pkg/providers/oci"
 	"github.com/helmfile/vals/pkg/providers/onepassword"
 	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
 	"github.com/helmfile/vals/pkg/providers/pulumi"
@@ -94,6 +95,7 @@ const (
 	ProviderAzureKeyVault      = "azurekeyvault"
 	ProviderEnvSubst           = "envsubst"
 	ProviderKeychain           = "keychain"
+	ProviderOCI                = "oci"
 	ProviderOnePassword        = "op"
 	ProviderOnePasswordConnect = "onepasswordconnect"
 	ProviderDoppler            = "doppler"
@@ -210,6 +212,9 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 			// 1. Get secret for key foo/bar, parse it as yaml
 			// 2. Then extracts the value for key baz) from the result from step 1.
 			p := awssecrets.New(r.logger, conf)
+			return p, nil
+		case ProviderOCI:
+			p := oci.New(r.logger, conf)
 			return p, nil
 		case ProviderSOPS:
 			p := sops.New(r.logger, conf)


### PR DESCRIPTION
We'd like to have direct OCI support to pull down yaml values.  Issue https://github.com/helmfile/vals/issues/694

This uses the ORAS go library and default docker credentials to access the file.  I'm using the default annotation ORAS looks for and allowing it to be overridden if needed.