### PR TITLE
Add support for Delinea Secret Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It supports various backends including:
 - HTTP JSON
 - Keychain
 - Scaleway
+- [Delinea SecretServer](https://delinea.com/products/secret-server)
 - Infisical
 
 - Use `vals eval -f refs.yaml` to replace all the `ref`s in the file to actual values and secrets.
@@ -309,6 +310,7 @@ Please see the [relevant unit test cases](https://github.com/helmfile/vals/blob/
     - [HTTP JSON](#http-json)
       - [Fetch string value](#fetch-string-value)
       - [Fetch integer value](#fetch-integer-value)
+    - [Delinea Secret Server](#secretserver)
   - [Advanced Usages](#advanced-usages)
     - [Discriminating config and secrets](#discriminating-config-and-secrets)
   - [Non-Goals](#non-goals)
@@ -1151,6 +1153,19 @@ Depending on which one is chosen with the `INFISICAL_AUTH_METHOD` environment va
   - `INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH`: the path to your GCP service account key file.
 - **GCP ID Token**: `GCP_ID_TOKEN`
   - `INFISICAL_GCP_AUTH_IDENTITY_ID`: your Infisical Machine Identity ID.
+
+### SecretServer
+
+This provider allows retrieval of secrets from [Delinea SecretSever](https://delinea.com/products/secret-server) using their [REST API](https://docs.delinea.com/online-help/secret-server/api-scripting/rest-api/index.htm)
+
+Environment variables:
+
+- `SECRETSERVER_TOKEN`: The API Token to authenticate with. Can be created using their [OAuth Endpoint](https://updates.thycotic.net/secretserver/restapiguide/OAuth/)
+- `SECRETSERVER_URL`: The URL to the SecretServer instance.
+
+Examples:
+
+- `ref+secretserver://12345/password`: gets the `password` field of the secret with id `12345` from the SecretServer running at the URL provdied in `SECRETSERVER_URL`
 
 ## Advanced Usages
 

--- a/pkg/providers/secretserver/secretserver.go
+++ b/pkg/providers/secretserver/secretserver.go
@@ -1,0 +1,127 @@
+package secretserver
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/helmfile/vals/pkg/api"
+)
+
+type secretServerSecret struct {
+	Items []secretServerSecretItem `json:"items"`
+}
+
+type secretServerSecretItem struct {
+	Slug      string `json:"slug"`
+	ItemValue string `json:"itemValue"`
+}
+
+type provider struct {
+	APIVersion string
+	SSLVerify  bool
+}
+
+func New(cfg api.StaticConfig) *provider {
+	p := &provider{}
+	v := cfg.String("ssl_verify")
+	p.SSLVerify = v != "false"
+
+	if a := cfg.String("api_version"); a == "" {
+		p.APIVersion = "v1"
+	} else {
+		p.APIVersion = a
+	}
+
+	return p
+}
+
+func (p *provider) GetString(key string) (string, error) {
+	splits := strings.Split(key, "/")
+	if len(splits) != 2 {
+		return "", fmt.Errorf("malformed key")
+	}
+	secretID := splits[0]
+	fieldName := splits[1]
+
+	g, err := p.getSecret(secretID)
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range g.Items {
+		if item.Slug == fieldName {
+			return item.ItemValue, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find field %s in secret", fieldName)
+}
+
+func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
+	secretMap := map[string]interface{}{}
+
+	secret, err := p.getSecret(key)
+	if err != nil {
+		return secretMap, err
+	}
+
+	for _, item := range secret.Items {
+		secretMap[item.Slug] = item.ItemValue
+	}
+
+	return secretMap, nil
+}
+
+func (p *provider) getSecret(secretID string) (secretServerSecret, error) {
+	var secret secretServerSecret
+	accessToken, ok := os.LookupEnv("SECRETSERVER_TOKEN")
+	if !ok {
+		return secret, errors.New("missing SECRETSERVER_TOKEN environment variable")
+	}
+	baseUrl, ok := os.LookupEnv("SECRETSERVER_URL")
+	if !ok {
+		return secret, errors.New("missing SECRETSERVER_URL environment variable")
+	}
+
+	url := fmt.Sprintf("%s/api/%s/secrets/%s",
+		baseUrl,
+		p.APIVersion,
+		secretID)
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !p.SSLVerify},
+	}
+	client := &http.Client{Transport: tr}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return secret, err
+	}
+	req.Header = http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return secret, err
+	}
+
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return secret, fmt.Errorf("SecretServer request %s failed: %s", req.URL, res.Status)
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&secret)
+	if err != nil {
+		return secret, fmt.Errorf("cannot decode JSON: %v", err)
+	}
+	return secret, nil
+}

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/helmfile/vals/pkg/providers/pulumi"
 	"github.com/helmfile/vals/pkg/providers/s3"
 	"github.com/helmfile/vals/pkg/providers/scaleway"
+	"github.com/helmfile/vals/pkg/providers/secretserver"
 	"github.com/helmfile/vals/pkg/providers/sops"
 	"github.com/helmfile/vals/pkg/providers/ssm"
 	"github.com/helmfile/vals/pkg/providers/tfstate"
@@ -86,6 +87,8 @@ func New(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.Lazy
 		return httpjson.New(l, provider), nil
 	case "scaleway":
 		return scaleway.New(l, provider), nil
+	case "secretserver":
+		return secretserver.New(provider), nil
 	case "infisical":
 		return infisical.New(l, provider), nil
 	}

--- a/vals.go
+++ b/vals.go
@@ -45,6 +45,7 @@ import (
 	"github.com/helmfile/vals/pkg/providers/pulumi"
 	"github.com/helmfile/vals/pkg/providers/s3"
 	"github.com/helmfile/vals/pkg/providers/scaleway"
+	"github.com/helmfile/vals/pkg/providers/secretserver"
 	"github.com/helmfile/vals/pkg/providers/servercore"
 	"github.com/helmfile/vals/pkg/providers/sops"
 	"github.com/helmfile/vals/pkg/providers/ssm"
@@ -111,6 +112,7 @@ const (
 	ProviderBitwarden          = "bw"
 	ProviderLockbox            = "yclockbox"
 	ProviderScaleway           = "scw"
+	ProviderSecretserver       = "secretserver"
 	ProviderInfisical          = "infisical"
 	ProviderServercore         = "servercore"
 )
@@ -297,6 +299,9 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 			return p, nil
 		case ProviderScaleway:
 			p := scaleway.New(r.logger, conf)
+			return p, nil
+		case ProviderSecretserver:
+			p := secretserver.New(conf)
 			return p, nil
 		case ProviderInfisical:
 			p := infisical.New(r.logger, conf)


### PR DESCRIPTION
Add support for [Delinea SecretSevers](https://delinea.com/products/secret-server) using their [REST API](https://docs.delinea.com/online-help/secret-server/api-scripting/rest-api/index.htm).

This was tested against a private Instance. I don't know if there is a public demo app to test against.