### PR TITLE
fix: wrong type cache entry at expansion's start is not an error

### DIFF
--- a/vals.go
+++ b/vals.go
@@ -347,10 +347,9 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 		Lookup: func(key string) (string, error) {
 			if val, ok := r.docCache.Get(key); ok {
 				valStr, ok := val.(string)
-				if !ok {
-					return "", fmt.Errorf("error reading string from cache: unsupported value type %T", val)
+				if ok {
+					return valStr, nil
 				}
-				return valStr, nil
 			}
 
 			uri, err := url.Parse(key)


### PR DESCRIPTION
At the beginning of an expansion, a cache entry *not* holding a string does not necessarily mean the expansion can't be done, so avoid  returning an error.

Add cases to test the caches in these situations.
---
As illustration, compare current version of vals' behavior with the proposed fix.

```
$ vals get 'ref+echo://foo/bar#/foo ref+echo://foo/bar'
expand echo://foo/bar: error reading string from cache: unsupported value type map[string]interface {}
```

vs

```
$ ./bin/vals get 'ref+echo://foo/bar#/foo ref+echo://foo/bar'; echo
bar foo/bar
```
