### PR TITLE
Add GitLab Terraform state provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Please see the [relevant unit test cases](https://github.com/helmfile/vals/blob/
     - [Terraform in S3 bucket (tfstates3)](#terraform-in-s3-bucket-tfstates3)
     - [Terraform in AzureRM Blob storage (tfstateazurerm)](#terraform-in-azurerm-blob-storage-tfstateazurerm)
     - [Terraform in Terraform Cloud / Terraform Enterprise (tfstateremote)](#terraform-in-terraform-cloud--terraform-enterprise-tfstateremote)
+    - [Terraform in GitLab (tfstategitlab)](#terraform-in-gitlab-tfstategitlab)
     - [SOPS](#sops)
     - [Keychain](#keychain)
     - [Echo](#echo)
@@ -733,6 +734,36 @@ which is equivalent to the following input for `vals`:
 
 ```
 $ echo 'foo: ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtual_network.name' | vals eval -f -
+```
+
+### Terraform in GitLab (tfstategitlab)
+
+- `ref+tfstategitlab://{gitlab_host}/api/v4/projects/{project_id}/terraform/state/{state_name}/RESOURCE_NAME[?gitlab_user=GITLAB_USER&gitlab_token=GITLAB_TOKEN]`
+
+* `gitlab_user` defaults to value of `GITLAB_USER` envvar.
+* `gitlab_token` defaults to value of `GITLAB_TOKEN` envvar.
+
+Examples:
+
+- `ref+tfstategitlab://gitlab.com/api/v4/projects/123/terraform/state/my-state/aws_vpc.main.id`
+- `ref+tfstategitlab://my-gitlab.com/api/v4/projects/xx/terraform/state/xxx/output.my_output`
+
+It allows to use Terraform state stored in GitLab given GitLab host, project ID and state name. You can try to read state with command:
+
+```
+$ tfstate-lookup -s https://username:password@my-gitlab.com/api/v4/projects/xx/terraform/state/xxx/ output.my_output
+```
+
+which is equivalent to following input for `vals` (with environment variables `GITLAB_USER` and `GITLAB_TOKEN`):
+
+```
+$ echo 'foo: ref+tfstategitlab://my-gitlab.com/api/v4/projects/xx/terraform/state/xxx/output.my_output' | vals eval -f -
+```
+
+Or you can provide credentials via URL parameters:
+
+```
+$ echo 'foo: ref+tfstategitlab://my-gitlab.com/api/v4/projects/xx/terraform/state/xxx/output.my_output?gitlab_user=username&gitlab_token=token' | vals eval -f -
 ```
 
 ### SOPS

--- a/README.md
+++ b/README.md
@@ -742,8 +742,9 @@ $ echo 'foo: ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtu
 
 * `gitlab_user` defaults to value of `GITLAB_USER` envvar.
 * `gitlab_token` defaults to value of `GITLAB_TOKEN` envvar.
+* `gitlab_scheme` selects `http` or `https` (defaults to `https`); use `http` for a self-hosted GitLab reachable over plain HTTP.
 
-GitLab authenticates the Terraform state backend via HTTP Basic Auth, so **both `gitlab_user` and `gitlab_token` are required** for authentication. If only one is set, the request is sent unauthenticated. Credentials may be provided via URL query parameters, via the `providers` config, or via environment variables (in that order of precedence).
+GitLab authenticates the Terraform state backend via HTTP Basic Auth, so **both `gitlab_user` and `gitlab_token` are required** for authentication. If only one is set, the request is sent unauthenticated and GitLab will return a clear HTTP 401 error. Credentials may be provided via URL query parameters, via the `providers` config, or via environment variables (in that order of precedence). Credentials are sent in the `Authorization` header and never appear in the request URL.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -743,6 +743,8 @@ $ echo 'foo: ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtu
 * `gitlab_user` defaults to value of `GITLAB_USER` envvar.
 * `gitlab_token` defaults to value of `GITLAB_TOKEN` envvar.
 
+GitLab authenticates the Terraform state backend via HTTP Basic Auth, so **both `gitlab_user` and `gitlab_token` are required** for authentication. If only one is set, the request is sent unauthenticated. Credentials may be provided via URL query parameters, via the `providers` config, or via environment variables (in that order of precedence).
+
 Examples:
 
 - `ref+tfstategitlab://gitlab.com/api/v4/projects/123/terraform/state/my-state/aws_vpc.main.id`

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -17,8 +17,6 @@ type provider struct {
 	backend          string
 	awsProfile       string
 	azSubscriptionId string
-	gitlabUser       string
-	gitlabToken      string
 }
 
 func New(cfg api.StaticConfig, backend string) *provider {
@@ -26,8 +24,6 @@ func New(cfg api.StaticConfig, backend string) *provider {
 	p.backend = backend
 	p.awsProfile = cfg.String("aws_profile")
 	p.azSubscriptionId = cfg.String("az_subscription_id")
-	p.gitlabUser = cfg.String("gitlab_user")
-	p.gitlabToken = cfg.String("gitlab_token")
 	return p
 }
 
@@ -105,14 +101,8 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 			stateURL = "https://" + f
 		}
 
-		user := p.gitlabUser
-		if user == "" {
-			user = os.Getenv("GITLAB_USER")
-		}
-		token := p.gitlabToken
-		if token == "" {
-			token = os.Getenv("GITLAB_TOKEN")
-		}
+		user := os.Getenv("GITLAB_USER")
+		token := os.Getenv("GITLAB_TOKEN")
 
 		parsedURL, err := url.Parse(stateURL)
 		if err != nil {

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -14,10 +14,11 @@ import (
 )
 
 type provider struct {
-	cfg              api.StaticConfig
 	backend          string
 	awsProfile       string
 	azSubscriptionId string
+	gitlabUser       string
+	gitlabToken      string
 }
 
 func New(cfg api.StaticConfig, backend string) *provider {
@@ -25,7 +26,8 @@ func New(cfg api.StaticConfig, backend string) *provider {
 	p.backend = backend
 	p.awsProfile = cfg.String("aws_profile")
 	p.azSubscriptionId = cfg.String("az_subscription_id")
-	p.cfg = cfg
+	p.gitlabUser = cfg.String("gitlab_user")
+	p.gitlabToken = cfg.String("gitlab_token")
 	return p
 }
 
@@ -103,11 +105,11 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 			stateURL = "https://" + f
 		}
 
-		user := p.cfg.String("gitlab_user")
+		user := p.gitlabUser
 		if user == "" {
 			user = os.Getenv("GITLAB_USER")
 		}
-		token := p.cfg.String("gitlab_token")
+		token := p.gitlabToken
 		if token == "" {
 			token = os.Getenv("GITLAB_TOKEN")
 		}

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -14,11 +14,10 @@ import (
 )
 
 type provider struct {
+	cfg              api.StaticConfig
 	backend          string
 	awsProfile       string
 	azSubscriptionId string
-	gitlabUser       string
-	gitlabToken      string
 }
 
 func New(cfg api.StaticConfig, backend string) *provider {
@@ -26,8 +25,7 @@ func New(cfg api.StaticConfig, backend string) *provider {
 	p.backend = backend
 	p.awsProfile = cfg.String("aws_profile")
 	p.azSubscriptionId = cfg.String("az_subscription_id")
-	p.gitlabUser = cfg.String("gitlab_user")
-	p.gitlabToken = cfg.String("gitlab_token")
+	p.cfg = cfg
 	return p
 }
 
@@ -105,11 +103,11 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 			stateURL = "https://" + f
 		}
 
-		user := p.gitlabUser
+		user := p.cfg.String("gitlab_user")
 		if user == "" {
 			user = os.Getenv("GITLAB_USER")
 		}
-		token := p.gitlabToken
+		token := p.cfg.String("gitlab_token")
 		if token == "" {
 			token = os.Getenv("GITLAB_TOKEN")
 		}

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -3,15 +3,23 @@ package tfstate
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fujiwara/tfstate-lookup/tfstate"
 
 	"github.com/helmfile/vals/pkg/api"
 )
+
+// gitlabStateHTTPTimeout bounds how long a single GitLab Terraform state fetch
+// may take. tfstate-lookup's ReadURL uses http.DefaultClient (no timeout), so we
+// perform the HTTP request ourselves with an explicit timeout for the gitlab backend.
+const gitlabStateHTTPTimeout = 30 * time.Second
 
 type provider struct {
 	backend          string
@@ -19,6 +27,7 @@ type provider struct {
 	azSubscriptionId string
 	gitlabUser       string
 	gitlabToken      string
+	gitlabScheme     string
 }
 
 func New(cfg api.StaticConfig, backend string) *provider {
@@ -28,6 +37,7 @@ func New(cfg api.StaticConfig, backend string) *provider {
 	p.azSubscriptionId = cfg.String("az_subscription_id")
 	p.gitlabUser = cfg.String("gitlab_user")
 	p.gitlabToken = cfg.String("gitlab_token")
+	p.gitlabScheme = cfg.String("gitlab_scheme")
 	return p
 }
 
@@ -100,12 +110,7 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 		}
 		return state, nil
 	case "gitlab":
-		stateURL, err := p.buildGitLabURL(f)
-		if err != nil {
-			return nil, err
-		}
-
-		state, err := tfstate.ReadURL(context.TODO(), stateURL)
+		state, err := p.readGitLab(context.TODO(), f)
 		if err != nil {
 			return nil, fmt.Errorf("reading tfstate for %s: %w", k, err)
 		}
@@ -124,16 +129,28 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 	return nil, fmt.Errorf("path fragment is not supported for tfstate provider")
 }
 
-// buildGitLabURL builds an authenticated GitLab Terraform state URL for f, which
-// is the bare host/path portion (e.g. "gitlab.com/api/v4/projects/123/terraform/state/my-state").
-//
-// Credentials are read from the provider config (gitlab_user / gitlab_token, which
-// can be supplied via vals config or ref+ URL query parameters) and fall back to
-// the GITLAB_USER / GITLAB_TOKEN environment variables.
-//
-// GitLab authenticates the Terraform state backend via HTTP Basic Auth requiring
-// both a username and a token, so credentials are only embedded when both are set.
+// buildGitLabURL builds the GitLab Terraform state URL for f (the bare host/path
+// portion such as "gitlab.com/api/v4/projects/123/terraform/state/my-state"). The
+// scheme defaults to https and can be overridden to http via the "gitlab_scheme"
+// config option for self-hosted GitLab instances reachable over plain HTTP. The
+// returned URL never carries credentials.
 func (p *provider) buildGitLabURL(f string) (string, error) {
+	scheme := p.gitlabScheme
+	if scheme != "http" && scheme != "https" {
+		scheme = "https"
+	}
+	parsedURL, err := url.Parse(scheme + "://" + f)
+	if err != nil {
+		return "", fmt.Errorf("parsing GitLab URL: %w", err)
+	}
+	return parsedURL.String(), nil
+}
+
+// resolveGitLabCreds resolves the GitLab username and token, preferring the
+// provider config (gitlab_user / gitlab_token, supplied via vals config or ref+
+// URL query parameters) and falling back to the GITLAB_USER / GITLAB_TOKEN
+// environment variables.
+func (p *provider) resolveGitLabCreds() (string, string) {
 	user := p.gitlabUser
 	if user == "" {
 		user = os.Getenv("GITLAB_USER")
@@ -142,15 +159,45 @@ func (p *provider) buildGitLabURL(f string) (string, error) {
 	if token == "" {
 		token = os.Getenv("GITLAB_TOKEN")
 	}
+	return user, token
+}
 
-	parsedURL, err := url.Parse("https://" + f)
+// readGitLab fetches the Terraform state from a GitLab HTTP backend and parses it.
+//
+// Authentication uses HTTP Basic Auth carried in the request Authorization header
+// (via req.SetBasicAuth) rather than the URL, so credentials never appear in URLs,
+// error messages, or logs. GitLab authenticates the Terraform state backend via
+// Basic Auth requiring both a username and a token, so the header is only set when
+// both are present; a missing credential surfaces as a clear HTTP 401 rather than
+// an opaque parse error.
+func (p *provider) readGitLab(ctx context.Context, f string) (*tfstate.TFState, error) {
+	stateURL, err := p.buildGitLabURL(f)
 	if err != nil {
-		return "", fmt.Errorf("parsing GitLab URL: %w", err)
+		return nil, err
 	}
 
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, stateURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating GitLab request: %w", err)
+	}
+
+	user, token := p.resolveGitLabCreds()
 	if user != "" && token != "" {
-		parsedURL.User = url.UserPassword(user, token)
+		req.SetBasicAuth(user, token)
 	}
 
-	return parsedURL.String(), nil
+	client := &http.Client{Timeout: gitlabStateHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting GitLab state: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// Drain so the connection can be reused by the transport's pool.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("GitLab returned HTTP %d for %s", resp.StatusCode, stateURL)
+	}
+
+	return tfstate.Read(ctx, resp.Body)
 }

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -17,6 +17,8 @@ type provider struct {
 	backend          string
 	awsProfile       string
 	azSubscriptionId string
+	gitlabUser       string
+	gitlabToken      string
 }
 
 func New(cfg api.StaticConfig, backend string) *provider {
@@ -24,6 +26,8 @@ func New(cfg api.StaticConfig, backend string) *provider {
 	p.backend = backend
 	p.awsProfile = cfg.String("aws_profile")
 	p.azSubscriptionId = cfg.String("az_subscription_id")
+	p.gitlabUser = cfg.String("gitlab_user")
+	p.gitlabToken = cfg.String("gitlab_token")
 	return p
 }
 
@@ -96,26 +100,12 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 		}
 		return state, nil
 	case "gitlab":
-		stateURL := f
-		if !strings.HasPrefix(stateURL, "http://") && !strings.HasPrefix(stateURL, "https://") {
-			stateURL = "https://" + f
-		}
-
-		user := os.Getenv("GITLAB_USER")
-		token := os.Getenv("GITLAB_TOKEN")
-
-		parsedURL, err := url.Parse(stateURL)
+		stateURL, err := p.buildGitLabURL(f)
 		if err != nil {
-			return nil, fmt.Errorf("parsing GitLab URL: %w", err)
+			return nil, err
 		}
 
-		if user != "" && token != "" {
-			parsedURL.User = url.UserPassword(user, token)
-		} else if token != "" {
-			parsedURL.User = url.UserPassword(token, "")
-		}
-
-		state, err := tfstate.ReadURL(context.TODO(), parsedURL.String())
+		state, err := tfstate.ReadURL(context.TODO(), stateURL)
 		if err != nil {
 			return nil, fmt.Errorf("reading tfstate for %s: %w", k, err)
 		}
@@ -132,4 +122,35 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 	return nil, fmt.Errorf("path fragment is not supported for tfstate provider")
+}
+
+// buildGitLabURL builds an authenticated GitLab Terraform state URL for f, which
+// is the bare host/path portion (e.g. "gitlab.com/api/v4/projects/123/terraform/state/my-state").
+//
+// Credentials are read from the provider config (gitlab_user / gitlab_token, which
+// can be supplied via vals config or ref+ URL query parameters) and fall back to
+// the GITLAB_USER / GITLAB_TOKEN environment variables.
+//
+// GitLab authenticates the Terraform state backend via HTTP Basic Auth requiring
+// both a username and a token, so credentials are only embedded when both are set.
+func (p *provider) buildGitLabURL(f string) (string, error) {
+	user := p.gitlabUser
+	if user == "" {
+		user = os.Getenv("GITLAB_USER")
+	}
+	token := p.gitlabToken
+	if token == "" {
+		token = os.Getenv("GITLAB_TOKEN")
+	}
+
+	parsedURL, err := url.Parse("https://" + f)
+	if err != nil {
+		return "", fmt.Errorf("parsing GitLab URL: %w", err)
+	}
+
+	if user != "" && token != "" {
+		parsedURL.User = url.UserPassword(user, token)
+	}
+
+	return parsedURL.String(), nil
 }

--- a/pkg/providers/tfstate/tfstate_test.go
+++ b/pkg/providers/tfstate/tfstate_test.go
@@ -29,9 +29,7 @@ func TestNewGitLabProvider(t *testing.T) {
 				"gitlab_token": "testtoken",
 			},
 			expected: &provider{
-				backend:     "gitlab",
-				gitlabUser:  "testuser",
-				gitlabToken: "testtoken",
+				backend: "gitlab",
 			},
 			name:    "with gitlab_user and gitlab_token",
 			backend: "gitlab",
@@ -52,8 +50,6 @@ func TestNewGitLabProvider(t *testing.T) {
 			p := New(cfg, tt.backend)
 
 			assert.Equal(t, tt.expected.backend, p.backend)
-			assert.Equal(t, tt.expected.gitlabUser, p.gitlabUser)
-			assert.Equal(t, tt.expected.gitlabToken, p.gitlabToken)
 		})
 	}
 }

--- a/pkg/providers/tfstate/tfstate_test.go
+++ b/pkg/providers/tfstate/tfstate_test.go
@@ -1,0 +1,67 @@
+package tfstate
+
+import (
+	"testing"
+
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGitLabProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      map[string]interface{}
+		backend  string
+		expected *provider
+	}{
+		{
+			name:    "default config",
+			cfg:     map[string]interface{}{},
+			backend: "gitlab",
+			expected: &provider{
+				backend: "gitlab",
+			},
+		},
+		{
+			name: "with gitlab_user and gitlab_token",
+			cfg: map[string]interface{}{
+				"gitlab_user":  "testuser",
+				"gitlab_token": "testtoken",
+			},
+			backend: "gitlab",
+			expected: &provider{
+				backend:     "gitlab",
+				gitlabUser:  "testuser",
+				gitlabToken: "testtoken",
+			},
+		},
+		{
+			name:    "s3 backend",
+			cfg:     map[string]interface{}{},
+			backend: "s3",
+			expected: &provider{
+				backend: "s3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.MapConfig{M: tt.cfg}
+			p := New(cfg, tt.backend)
+
+			assert.Equal(t, tt.expected.backend, p.backend)
+			assert.Equal(t, tt.expected.gitlabUser, p.gitlabUser)
+			assert.Equal(t, tt.expected.gitlabToken, p.gitlabToken)
+		})
+	}
+}
+
+func TestProvider_GetStringMap(t *testing.T) {
+	cfg := config.MapConfig{M: map[string]interface{}{}}
+	p := New(cfg, "gitlab")
+
+	_, err := p.GetStringMap("test/path")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "path fragment is not supported for tfstate provider")
+}

--- a/pkg/providers/tfstate/tfstate_test.go
+++ b/pkg/providers/tfstate/tfstate_test.go
@@ -29,7 +29,9 @@ func TestNewGitLabProvider(t *testing.T) {
 				"gitlab_token": "testtoken",
 			},
 			expected: &provider{
-				backend: "gitlab",
+				gitlabUser:  "testuser",
+				gitlabToken: "testtoken",
+				backend:     "gitlab",
 			},
 			name:    "with gitlab_user and gitlab_token",
 			backend: "gitlab",
@@ -50,6 +52,8 @@ func TestNewGitLabProvider(t *testing.T) {
 			p := New(cfg, tt.backend)
 
 			assert.Equal(t, tt.expected.backend, p.backend)
+			assert.Equal(t, tt.expected.gitlabUser, p.gitlabUser)
+			assert.Equal(t, tt.expected.gitlabToken, p.gitlabToken)
 		})
 	}
 }

--- a/pkg/providers/tfstate/tfstate_test.go
+++ b/pkg/providers/tfstate/tfstate_test.go
@@ -3,45 +3,46 @@ package tfstate
 import (
 	"testing"
 
-	"github.com/helmfile/vals/pkg/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/helmfile/vals/pkg/config"
 )
 
 func TestNewGitLabProvider(t *testing.T) {
 	tests := []struct {
-		name     string
 		cfg      map[string]interface{}
-		backend  string
 		expected *provider
+		name     string
+		backend  string
 	}{
 		{
-			name:    "default config",
-			cfg:     map[string]interface{}{},
-			backend: "gitlab",
+			cfg: map[string]interface{}{},
 			expected: &provider{
 				backend: "gitlab",
 			},
+			name:    "default config",
+			backend: "gitlab",
 		},
 		{
-			name: "with gitlab_user and gitlab_token",
 			cfg: map[string]interface{}{
 				"gitlab_user":  "testuser",
 				"gitlab_token": "testtoken",
 			},
-			backend: "gitlab",
 			expected: &provider{
 				backend:     "gitlab",
 				gitlabUser:  "testuser",
 				gitlabToken: "testtoken",
 			},
+			name:    "with gitlab_user and gitlab_token",
+			backend: "gitlab",
 		},
 		{
-			name:    "s3 backend",
-			cfg:     map[string]interface{}{},
-			backend: "s3",
+			cfg: map[string]interface{}{},
 			expected: &provider{
 				backend: "s3",
 			},
+			name:    "s3 backend",
+			backend: "s3",
 		},
 	}
 

--- a/pkg/providers/tfstate/tfstate_test.go
+++ b/pkg/providers/tfstate/tfstate_test.go
@@ -29,9 +29,7 @@ func TestNewGitLabProvider(t *testing.T) {
 				"gitlab_token": "testtoken",
 			},
 			expected: &provider{
-				gitlabUser:  "testuser",
-				gitlabToken: "testtoken",
-				backend:     "gitlab",
+				backend: "gitlab",
 			},
 			name:    "with gitlab_user and gitlab_token",
 			backend: "gitlab",
@@ -52,8 +50,6 @@ func TestNewGitLabProvider(t *testing.T) {
 			p := New(cfg, tt.backend)
 
 			assert.Equal(t, tt.expected.backend, p.backend)
-			assert.Equal(t, tt.expected.gitlabUser, p.gitlabUser)
-			assert.Equal(t, tt.expected.gitlabToken, p.gitlabToken)
 		})
 	}
 }

--- a/pkg/providers/tfstate/tfstate_test.go
+++ b/pkg/providers/tfstate/tfstate_test.go
@@ -8,39 +8,34 @@ import (
 	"github.com/helmfile/vals/pkg/config"
 )
 
-func TestNewGitLabProvider(t *testing.T) {
+func TestNew(t *testing.T) {
 	tests := []struct {
-		cfg      map[string]interface{}
-		expected *provider
-		name     string
-		backend  string
+		name        string
+		cfg         map[string]interface{}
+		backend     string
+		wantBackend string
+		wantUser    string
+		wantToken   string
 	}{
 		{
-			cfg: map[string]interface{}{},
-			expected: &provider{
-				backend: "gitlab",
-			},
-			name:    "default config",
-			backend: "gitlab",
+			name:        "gitlab default config",
+			cfg:         map[string]interface{}{},
+			backend:     "gitlab",
+			wantBackend: "gitlab",
 		},
 		{
-			cfg: map[string]interface{}{
-				"gitlab_user":  "testuser",
-				"gitlab_token": "testtoken",
-			},
-			expected: &provider{
-				backend: "gitlab",
-			},
-			name:    "with gitlab_user and gitlab_token",
-			backend: "gitlab",
+			name:        "gitlab with credentials from config",
+			cfg:         map[string]interface{}{"gitlab_user": "alice", "gitlab_token": "cfgtoken"},
+			backend:     "gitlab",
+			wantBackend: "gitlab",
+			wantUser:    "alice",
+			wantToken:   "cfgtoken",
 		},
 		{
-			cfg: map[string]interface{}{},
-			expected: &provider{
-				backend: "s3",
-			},
-			name:    "s3 backend",
-			backend: "s3",
+			name:        "s3 backend reads aws_profile",
+			cfg:         map[string]interface{}{"aws_profile": "prof", "az_subscription_id": "sub"},
+			backend:     "s3",
+			wantBackend: "s3",
 		},
 	}
 
@@ -49,7 +44,63 @@ func TestNewGitLabProvider(t *testing.T) {
 			cfg := config.MapConfig{M: tt.cfg}
 			p := New(cfg, tt.backend)
 
-			assert.Equal(t, tt.expected.backend, p.backend)
+			assert.Equal(t, tt.wantBackend, p.backend)
+			assert.Equal(t, tt.wantUser, p.gitlabUser)
+			assert.Equal(t, tt.wantToken, p.gitlabToken)
+		})
+	}
+}
+
+func TestBuildGitLabURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       map[string]interface{}
+		envUser   string
+		envToken  string
+		hostPath  string
+		wantCreds string
+	}{
+		{
+			name:     "no credentials yields unauthenticated url",
+			hostPath: "gitlab.com/api/v4/projects/123/terraform/state/my-state",
+		},
+		{
+			name:      "credentials from config",
+			cfg:       map[string]interface{}{"gitlab_user": "alice", "gitlab_token": "cfgtoken"},
+			hostPath:  "my-gitlab.com/api/v4/projects/9/terraform/state/web",
+			wantCreds: "alice:cfgtoken@",
+		},
+		{
+			name:      "credentials from env vars",
+			envUser:   "bob",
+			envToken:  "envtoken",
+			hostPath:  "gitlab.example.com/api/v4/projects/1/terraform/state/db",
+			wantCreds: "bob:envtoken@",
+		},
+		{
+			name:      "config takes precedence over env",
+			cfg:       map[string]interface{}{"gitlab_user": "alice", "gitlab_token": "cfgtoken"},
+			envUser:   "bob",
+			envToken:  "envtoken",
+			hostPath:  "gitlab.com/api/v4/projects/2/terraform/state/vpc",
+			wantCreds: "alice:cfgtoken@",
+		},
+		{
+			name:     "token alone does not authenticate (both required)",
+			envToken: "onlytoken",
+			hostPath: "onprem-gitlab.local/api/v4/projects/7/terraform/state/net",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITLAB_USER", tt.envUser)
+			t.Setenv("GITLAB_TOKEN", tt.envToken)
+
+			p := New(config.MapConfig{M: tt.cfg}, "gitlab")
+			got, err := p.buildGitLabURL(tt.hostPath)
+			assert.NoError(t, err)
+			assert.Equal(t, "https://"+tt.wantCreds+tt.hostPath, got)
 		})
 	}
 }

--- a/pkg/providers/tfstate/tfstate_test.go
+++ b/pkg/providers/tfstate/tfstate_test.go
@@ -1,12 +1,19 @@
 package tfstate
 
 import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/helmfile/vals/pkg/config"
 )
+
+const fakeTFStateJSON = `{"version":4,"terraform_version":"1.5.7","serial":1,"lineage":"test","outputs":{},"resources":[]}`
 
 func TestNew(t *testing.T) {
 	tests := []struct {
@@ -16,6 +23,7 @@ func TestNew(t *testing.T) {
 		wantBackend string
 		wantUser    string
 		wantToken   string
+		wantScheme  string
 	}{
 		{
 			name:        "gitlab default config",
@@ -24,12 +32,13 @@ func TestNew(t *testing.T) {
 			wantBackend: "gitlab",
 		},
 		{
-			name:        "gitlab with credentials from config",
-			cfg:         map[string]interface{}{"gitlab_user": "alice", "gitlab_token": "cfgtoken"},
+			name:        "gitlab reads credentials and scheme from config",
+			cfg:         map[string]interface{}{"gitlab_user": "alice", "gitlab_token": "cfgtoken", "gitlab_scheme": "http"},
 			backend:     "gitlab",
 			wantBackend: "gitlab",
 			wantUser:    "alice",
 			wantToken:   "cfgtoken",
+			wantScheme:  "http",
 		},
 		{
 			name:        "s3 backend reads aws_profile",
@@ -47,48 +56,70 @@ func TestNew(t *testing.T) {
 			assert.Equal(t, tt.wantBackend, p.backend)
 			assert.Equal(t, tt.wantUser, p.gitlabUser)
 			assert.Equal(t, tt.wantToken, p.gitlabToken)
+			assert.Equal(t, tt.wantScheme, p.gitlabScheme)
 		})
 	}
 }
 
 func TestBuildGitLabURL(t *testing.T) {
+	const hostPath = "gitlab.com/api/v4/projects/123/terraform/state/my-state"
+
+	tests := []struct {
+		name   string
+		scheme string
+		want   string
+	}{
+		{name: "defaults to https", scheme: "", want: "https://" + hostPath},
+		{name: "https explicit", scheme: "https", want: "https://" + hostPath},
+		{name: "http allowed", scheme: "http", want: "http://" + hostPath},
+		{name: "invalid scheme falls back to https", scheme: "ftp", want: "https://" + hostPath},
+		{name: "schemes never end up in the URL", scheme: "javascript", want: "https://" + hostPath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New(config.MapConfig{M: map[string]interface{}{"gitlab_scheme": tt.scheme}}, "gitlab")
+			got, err := p.buildGitLabURL(hostPath)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			// credentials must never be embedded in the URL
+			assert.NotContains(t, got, "@")
+		})
+	}
+}
+
+func TestResolveGitLabCreds(t *testing.T) {
 	tests := []struct {
 		name      string
 		cfg       map[string]interface{}
 		envUser   string
 		envToken  string
-		hostPath  string
-		wantCreds string
+		wantUser  string
+		wantToken string
 	}{
 		{
-			name:     "no credentials yields unauthenticated url",
-			hostPath: "gitlab.com/api/v4/projects/123/terraform/state/my-state",
-		},
-		{
-			name:      "credentials from config",
+			name:      "config credentials",
 			cfg:       map[string]interface{}{"gitlab_user": "alice", "gitlab_token": "cfgtoken"},
-			hostPath:  "my-gitlab.com/api/v4/projects/9/terraform/state/web",
-			wantCreds: "alice:cfgtoken@",
+			wantUser:  "alice",
+			wantToken: "cfgtoken",
 		},
 		{
-			name:      "credentials from env vars",
+			name:      "env fallback",
 			envUser:   "bob",
 			envToken:  "envtoken",
-			hostPath:  "gitlab.example.com/api/v4/projects/1/terraform/state/db",
-			wantCreds: "bob:envtoken@",
+			wantUser:  "bob",
+			wantToken: "envtoken",
 		},
 		{
 			name:      "config takes precedence over env",
 			cfg:       map[string]interface{}{"gitlab_user": "alice", "gitlab_token": "cfgtoken"},
 			envUser:   "bob",
 			envToken:  "envtoken",
-			hostPath:  "gitlab.com/api/v4/projects/2/terraform/state/vpc",
-			wantCreds: "alice:cfgtoken@",
+			wantUser:  "alice",
+			wantToken: "cfgtoken",
 		},
 		{
-			name:     "token alone does not authenticate (both required)",
-			envToken: "onlytoken",
-			hostPath: "onprem-gitlab.local/api/v4/projects/7/terraform/state/net",
+			name: "no credentials at all",
 		},
 	}
 
@@ -98,11 +129,82 @@ func TestBuildGitLabURL(t *testing.T) {
 			t.Setenv("GITLAB_TOKEN", tt.envToken)
 
 			p := New(config.MapConfig{M: tt.cfg}, "gitlab")
-			got, err := p.buildGitLabURL(tt.hostPath)
-			assert.NoError(t, err)
-			assert.Equal(t, "https://"+tt.wantCreds+tt.hostPath, got)
+			user, token := p.resolveGitLabCreds()
+			assert.Equal(t, tt.wantUser, user)
+			assert.Equal(t, tt.wantToken, token)
 		})
 	}
+}
+
+// newAuthGitLabServer returns an httptest server that serves fake TF state only
+// to requests authenticated as alice:tok, returning 401 otherwise.
+func newAuthGitLabServer(t *testing.T, gotAuth *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotAuth = r.Header.Get("Authorization")
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "alice" || pass != "tok" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fakeTFStateJSON))
+	}))
+}
+
+func TestReadGitLab_SuccessSendsBasicAuthAndParsesState(t *testing.T) {
+	var gotAuth string
+	srv := newAuthGitLabServer(t, &gotAuth)
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	cfg := config.MapConfig{M: map[string]interface{}{
+		"gitlab_user": "alice", "gitlab_token": "tok", "gitlab_scheme": "http",
+	}}
+	p := New(cfg, "gitlab")
+
+	state, err := p.readGitLab(context.Background(), host+"/api/v4/projects/1/terraform/state/s")
+	assert.NoError(t, err)
+	assert.NotNil(t, state)
+
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:tok"))
+	assert.Equal(t, wantAuth, gotAuth)
+}
+
+func TestReadGitLab_UnauthorizedSurfacesClearErrorWithoutToken(t *testing.T) {
+	var gotAuth string
+	srv := newAuthGitLabServer(t, &gotAuth)
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	cfg := config.MapConfig{M: map[string]interface{}{
+		"gitlab_user": "alice", "gitlab_token": "WRONG", "gitlab_scheme": "http",
+	}}
+	p := New(cfg, "gitlab")
+
+	_, err := p.readGitLab(context.Background(), host+"/api/v4/projects/1/terraform/state/s")
+	assert.Error(t, err)
+	// clear, actionable status code instead of an opaque JSON parse error
+	assert.Contains(t, err.Error(), "401")
+	// the token must never leak into the error (it is sent via header, not the URL)
+	assert.NotContains(t, err.Error(), "WRONG")
+}
+
+func TestReadGitLab_MissingCredentialsYieldsClearError(t *testing.T) {
+	var gotAuth string
+	srv := newAuthGitLabServer(t, &gotAuth)
+	defer srv.Close()
+
+	t.Setenv("GITLAB_USER", "")
+	t.Setenv("GITLAB_TOKEN", "")
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	p := New(config.MapConfig{M: map[string]interface{}{"gitlab_scheme": "http"}}, "gitlab")
+
+	_, err := p.readGitLab(context.Background(), host+"/api/v4/projects/1/terraform/state/s")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+	assert.Empty(t, gotAuth) // no Authorization header was sent
 }
 
 func TestProvider_GetStringMap(t *testing.T) {

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -61,6 +61,8 @@ func New(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.Lazy
 		return tfstate.New(provider, "azurerm"), nil
 	case "tfstateremote":
 		return tfstate.New(provider, "remote"), nil
+	case "tfstategitlab":
+		return tfstate.New(provider, "gitlab"), nil
 	case "azurekeyvault":
 		return azurekeyvault.New(provider), nil
 	case "gitlab":

--- a/vals.go
+++ b/vals.go
@@ -98,6 +98,7 @@ const (
 	ProviderTFStateS3          = "tfstates3"
 	ProviderTFStateAzureRM     = "tfstateazurerm"
 	ProviderTFStateRemote      = "tfstateremote"
+	ProviderTFStateGitLab      = "tfstategitlab"
 	ProviderAzureKeyVault      = "azurekeyvault"
 	ProviderEnvSubst           = "envsubst"
 	ProviderKeychain           = "keychain"
@@ -255,6 +256,9 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 			return p, nil
 		case ProviderTFStateRemote:
 			p := tfstate.New(conf, "remote")
+			return p, nil
+		case ProviderTFStateGitLab:
+			p := tfstate.New(conf, "gitlab")
 			return p, nil
 		case ProviderAzureKeyVault:
 			p := azurekeyvault.New(conf)


### PR DESCRIPTION
## Summary
Add support for reading Terraform state from GitLab using HTTP(S) URLs with GitLab authentication. This allows vals to fetch tfstate from GitLab's Terraform state backend using `GITLAB_USER` and `GITLAB_TOKEN` credentials.

## Changes
- Add `ProviderTFStateGitLab` constant and provider case in vals.go
- Extend tfstate provider to support GitLab backend with auth
- Add `gitlab_user` and `gitlab_token` config options
- Support `GITLAB_USER` and `GITLAB_TOKEN` environment variables
- Add `tfstategitlab` to stringprovider for ref+ syntax support
- Add unit tests for GitLab provider
- Add documentation in README

## Usage

With environment variables:
```bash
export GITLAB_USER="username"
export GITLAB_TOKEN="pat-token"
```

Or in vals config:
```yaml
providers:
  - name: tfstategitlab
    gitlab_user: username
    gitlab_token: pat-token
```

Then reference values:
```yaml
my_value: ref+tfstategitlab://gitlab.com/api/v4/projects/123/terraform/state/my-state/aws_vpc.main.id
```

Fixes #661