### PR TITLE
Replace manual disk cleanup with jlumbroso/free-disk-space action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,15 +17,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-      - name: cleanup disk
-        run: |
-            sudo rm -rf /usr/share/dotnet
-            sudo rm -rf /opt/ghc
-            sudo rm -rf /usr/local/share/boost
-            sudo rm -fr /usr/local/lib/android
-            sudo rm -fr /opt/hostedtoolcache/CodeQL
-            sudo docker image prune --all --force
-            sudo docker builder prune -a --force
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary

- Replaced manual disk cleanup shell commands with `jlumbroso/free-disk-space@v1` GitHub Action
- Simplified workflow configuration by using a dedicated action
- The action can free up to 31GB of disk space on Ubuntu runners