### PR TITLE
Optional provider builds via Go build tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,5 +16,7 @@ jobs:
       with:
         go-version-file: 'go.mod'
         cache: true
-    - name: build 
+    - name: build
       run: make build
+    - name: build (minimal, without optional providers)
+      run: go build -tags custom_providers -o /dev/null ./cmd/vals

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 cover.out
 vals
 .vscode
+.codex-review/
+vals-all

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ It supports various backends including:
 ToC:
 
 - [Installation](#installation)
+  - [Building from source](#building-from-source)
 - [Usage](#usage)
   - [CLI](#cli)
   - [Helm](#helm)
@@ -87,6 +88,29 @@ nix profile install nixpkgs#vals
 ```sh
 scoop install vals
 ```
+
+### Building from source
+
+```sh
+go build -o vals ./cmd/vals
+```
+
+#### Custom builds
+
+By default, all providers are compiled into the binary. If you only need specific providers, you can use Go build tags to produce a smaller binary:
+
+```sh
+# Only include Vault, AWS, GCP and Azure providers
+go build -tags "custom_providers,vault,aws,gcp,azure" -o vals ./cmd/vals
+```
+
+The `custom_providers` tag switches to opt-in mode. Without it, all providers are included. Add the tags for the providers you need:
+
+`vault`, `openbao`, `aws`, `gcp`, `azure`, `terraform`, `gitlab`, `sops`, `onepassword`, `doppler`, `k8s`, `hcpvaultsecrets`, `conjur`, `bitwarden`, `scaleway`, `infisical`, `oci`, `httpjson`, `pulumi`, `secretserver`, `servercore`, `keychain`, `yandex`
+
+Utility providers (`echo`, `file`, `envsubst`, `exec`) are always included.
+
+Use `all_providers` to explicitly include everything: `go build -tags all_providers`.
 
 ## Usage
 

--- a/pkg/providers/registry/registry.go
+++ b/pkg/providers/registry/registry.go
@@ -6,19 +6,44 @@ import (
 	"github.com/helmfile/vals/pkg/log"
 )
 
-// ProviderFactory creates a provider given a logger and configuration.
-type ProviderFactory func(l *log.Logger, conf config.MapConfig) (api.Provider, error)
+// ProviderFactory creates a provider for use in vals.go createProvider.
+type ProviderFactory func(l *log.Logger, conf config.MapConfig, awsLogLevel string) (api.Provider, error)
 
-var providers = map[string]ProviderFactory{}
+// StringProviderFactory creates a string provider for use in stringprovider.New.
+type StringProviderFactory func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringProvider, error)
 
-// Register adds a provider factory under the given scheme name.
-// It is intended to be called from init() functions in build-tag-guarded files.
-func Register(scheme string, factory ProviderFactory) {
-	providers[scheme] = factory
+// StringMapProviderFactory creates a string-map provider for use in stringmapprovider.New.
+type StringMapProviderFactory func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringMapProvider, error)
+
+var (
+	providers          = map[string]ProviderFactory{}
+	stringProviders    = map[string]StringProviderFactory{}
+	stringMapProviders = map[string]StringMapProviderFactory{}
+)
+
+func RegisterProvider(scheme string, f ProviderFactory) {
+	providers[scheme] = f
 }
 
-// Get returns the provider factory for the given scheme, if registered.
-func Get(scheme string) (ProviderFactory, bool) {
+func GetProvider(scheme string) (ProviderFactory, bool) {
 	f, ok := providers[scheme]
+	return f, ok
+}
+
+func RegisterStringProvider(name string, f StringProviderFactory) {
+	stringProviders[name] = f
+}
+
+func GetStringProvider(name string) (StringProviderFactory, bool) {
+	f, ok := stringProviders[name]
+	return f, ok
+}
+
+func RegisterStringMapProvider(name string, f StringMapProviderFactory) {
+	stringMapProviders[name] = f
+}
+
+func GetStringMapProvider(name string) (StringMapProviderFactory, bool) {
+	f, ok := stringMapProviders[name]
 	return f, ok
 }

--- a/pkg/providers/registry/registry.go
+++ b/pkg/providers/registry/registry.go
@@ -1,0 +1,24 @@
+package registry
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+)
+
+// ProviderFactory creates a provider given a logger and configuration.
+type ProviderFactory func(l *log.Logger, conf config.MapConfig) (api.Provider, error)
+
+var providers = map[string]ProviderFactory{}
+
+// Register adds a provider factory under the given scheme name.
+// It is intended to be called from init() functions in build-tag-guarded files.
+func Register(scheme string, factory ProviderFactory) {
+	providers[scheme] = factory
+}
+
+// Get returns the provider factory for the given scheme, if registered.
+func Get(scheme string) (ProviderFactory, bool) {
+	f, ok := providers[scheme]
+	return f, ok
+}

--- a/pkg/stringmapprovider/register_aws.go
+++ b/pkg/stringmapprovider/register_aws.go
@@ -1,0 +1,28 @@
+//go:build aws || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/awskms"
+	"github.com/helmfile/vals/pkg/providers/awssecrets"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/s3"
+	"github.com/helmfile/vals/pkg/providers/ssm"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("s3", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringMapProvider, error) {
+		return s3.New(l, provider, awsLogLevel), nil
+	})
+	registry.RegisterStringMapProvider("ssm", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringMapProvider, error) {
+		return ssm.New(l, provider, awsLogLevel), nil
+	})
+	registry.RegisterStringMapProvider("awssecrets", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringMapProvider, error) {
+		return awssecrets.New(l, provider, awsLogLevel), nil
+	})
+	registry.RegisterStringMapProvider("awskms", func(_ *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringMapProvider, error) {
+		return awskms.New(provider, awsLogLevel), nil
+	})
+}

--- a/pkg/stringmapprovider/register_azure.go
+++ b/pkg/stringmapprovider/register_azure.go
@@ -1,0 +1,16 @@
+//go:build azure || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/azurekeyvault"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("azurekeyvault", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return azurekeyvault.New(provider), nil
+	})
+}

--- a/pkg/stringmapprovider/register_doppler.go
+++ b/pkg/stringmapprovider/register_doppler.go
@@ -1,0 +1,16 @@
+//go:build doppler || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/doppler"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("doppler", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return doppler.New(l, provider), nil
+	})
+}

--- a/pkg/stringmapprovider/register_gcp.go
+++ b/pkg/stringmapprovider/register_gcp.go
@@ -1,0 +1,20 @@
+//go:build gcp || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/gcpsecrets"
+	"github.com/helmfile/vals/pkg/providers/gkms"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("gcpsecrets", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return gcpsecrets.New(provider), nil
+	})
+	registry.RegisterStringMapProvider("gkms", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return gkms.New(l, provider), nil
+	})
+}

--- a/pkg/stringmapprovider/register_httpjson.go
+++ b/pkg/stringmapprovider/register_httpjson.go
@@ -1,0 +1,16 @@
+//go:build httpjson || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/httpjson"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("httpjson", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return httpjson.New(l, provider), nil
+	})
+}

--- a/pkg/stringmapprovider/register_infisical.go
+++ b/pkg/stringmapprovider/register_infisical.go
@@ -1,0 +1,16 @@
+//go:build infisical || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/infisical"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("infisical", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return infisical.New(l, provider), nil
+	})
+}

--- a/pkg/stringmapprovider/register_k8s.go
+++ b/pkg/stringmapprovider/register_k8s.go
@@ -1,0 +1,16 @@
+//go:build k8s || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/k8s"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("k8s", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return k8s.New(l, provider)
+	})
+}

--- a/pkg/stringmapprovider/register_onepassword.go
+++ b/pkg/stringmapprovider/register_onepassword.go
@@ -1,0 +1,16 @@
+//go:build onepassword || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("onepasswordconnect", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return onepasswordconnect.New(provider), nil
+	})
+}

--- a/pkg/stringmapprovider/register_scaleway.go
+++ b/pkg/stringmapprovider/register_scaleway.go
@@ -1,0 +1,16 @@
+//go:build scaleway || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/scaleway"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("scaleway", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return scaleway.New(l, provider), nil
+	})
+}

--- a/pkg/stringmapprovider/register_sops.go
+++ b/pkg/stringmapprovider/register_sops.go
@@ -1,0 +1,16 @@
+//go:build sops || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/sops"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("sops", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringMapProvider, error) {
+		return sops.New(l, provider, awsLogLevel), nil
+	})
+}

--- a/pkg/stringmapprovider/register_vault.go
+++ b/pkg/stringmapprovider/register_vault.go
@@ -1,0 +1,16 @@
+//go:build vault || all_providers || !custom_providers
+
+package stringmapprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/vault"
+)
+
+func init() {
+	registry.RegisterStringMapProvider("vault", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringMapProvider, error) {
+		return vault.New(l, provider), nil
+	})
+}

--- a/pkg/stringmapprovider/stringmapprovider.go
+++ b/pkg/stringmapprovider/stringmapprovider.go
@@ -5,59 +5,20 @@ import (
 
 	"github.com/helmfile/vals/pkg/api"
 	"github.com/helmfile/vals/pkg/log"
-	"github.com/helmfile/vals/pkg/providers/awskms"
-	"github.com/helmfile/vals/pkg/providers/awssecrets"
-	"github.com/helmfile/vals/pkg/providers/azurekeyvault"
-	"github.com/helmfile/vals/pkg/providers/doppler"
 	execprovider "github.com/helmfile/vals/pkg/providers/exec"
-	"github.com/helmfile/vals/pkg/providers/gcpsecrets"
-	"github.com/helmfile/vals/pkg/providers/gkms"
-	"github.com/helmfile/vals/pkg/providers/httpjson"
-	"github.com/helmfile/vals/pkg/providers/infisical"
-	"github.com/helmfile/vals/pkg/providers/k8s"
-	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
-	"github.com/helmfile/vals/pkg/providers/scaleway"
-	"github.com/helmfile/vals/pkg/providers/sops"
-	"github.com/helmfile/vals/pkg/providers/ssm"
-	"github.com/helmfile/vals/pkg/providers/vault"
+	"github.com/helmfile/vals/pkg/providers/registry"
 )
 
 func New(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringMapProvider, error) {
 	tpe := provider.String("name")
 
 	switch tpe {
-	case "s3":
-		return ssm.New(l, provider, awsLogLevel), nil
-	case "ssm":
-		return ssm.New(l, provider, awsLogLevel), nil
-	case "vault":
-		return vault.New(l, provider), nil
-	case "awssecrets":
-		return awssecrets.New(l, provider, awsLogLevel), nil
-	case "sops":
-		return sops.New(l, provider, awsLogLevel), nil
-	case "gcpsecrets":
-		return gcpsecrets.New(provider), nil
-	case "azurekeyvault":
-		return azurekeyvault.New(provider), nil
-	case "awskms":
-		return awskms.New(provider, awsLogLevel), nil
-	case "onepasswordconnect":
-		return onepasswordconnect.New(provider), nil
-	case "doppler":
-		return doppler.New(l, provider), nil
-	case "gkms":
-		return gkms.New(l, provider), nil
-	case "k8s":
-		return k8s.New(l, provider)
-	case "httpjson":
-		return httpjson.New(l, provider), nil
-	case "scaleway":
-		return scaleway.New(l, provider), nil
-	case "infisical":
-		return infisical.New(l, provider), nil
 	case "exec":
 		return execprovider.New(l, provider), nil
+	default:
+		if factory, ok := registry.GetStringMapProvider(tpe); ok {
+			return factory(l, provider, awsLogLevel)
+		}
 	}
 
 	return nil, fmt.Errorf("failed initializing string-map provider from config: %v", provider)

--- a/pkg/stringmapprovider/stringmapprovider_test.go
+++ b/pkg/stringmapprovider/stringmapprovider_test.go
@@ -1,0 +1,60 @@
+package stringmapprovider
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+)
+
+// TestS3ProviderCallsS3API verifies that stringmapprovider with name "s3"
+// actually uses the S3 provider (GetObject), not the SSM provider
+// (GetParametersByPath).
+//
+// This is a regression test for a copy-paste bug (introduced in eafc4c0, 2020)
+// where the "s3" case returned ssm.New() instead of s3.New().
+// The bug was invisible at the s3 package level (s3_test.go tests the provider
+// directly), so we need this integration-style test at the routing layer.
+//
+// We verify by inspecting the error message: the S3 provider returns errors
+// mentioning "s3 object" while the SSM provider returns errors mentioning
+// "ssm" or "GetParametersByPath".
+func TestS3ProviderCallsS3API(t *testing.T) {
+	// Use a non-routable endpoint so the request fails fast with a
+	// provider-specific error message we can inspect.
+	t.Setenv("AWS_ENDPOINT_URL", "http://192.0.2.1:1") // TEST-NET-1, guaranteed non-routable
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+
+	l := log.New(log.Config{Output: os.Stderr})
+	cfg := config.Map(map[string]interface{}{
+		"name":   "s3",
+		"region": "us-east-1",
+	})
+
+	p, err := New(l, cfg, "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	_, err = p.GetStringMap("mybucket/mykey")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	errMsg := err.Error()
+	t.Logf("error: %s", errMsg)
+
+	// The S3 provider wraps errors as "getting s3 object: ..." and the
+	// underlying SDK error mentions "S3: GetObject".
+	// The SSM provider would produce errors mentioning "ssm" or
+	// "GetParametersByPath".
+	if strings.Contains(errMsg, "GetParametersByPath") || strings.Contains(errMsg, "SSM") {
+		t.Errorf("s3 stringmapprovider used SSM provider instead of S3:\n  error: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "s3") && !strings.Contains(errMsg, "S3") {
+		t.Errorf("expected error to mention S3, got: %s", errMsg)
+	}
+}

--- a/pkg/stringprovider/register_aws.go
+++ b/pkg/stringprovider/register_aws.go
@@ -1,0 +1,28 @@
+//go:build aws || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/awskms"
+	"github.com/helmfile/vals/pkg/providers/awssecrets"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/s3"
+	"github.com/helmfile/vals/pkg/providers/ssm"
+)
+
+func init() {
+	registry.RegisterStringProvider("s3", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringProvider, error) {
+		return s3.New(l, provider, awsLogLevel), nil
+	})
+	registry.RegisterStringProvider("ssm", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringProvider, error) {
+		return ssm.New(l, provider, awsLogLevel), nil
+	})
+	registry.RegisterStringProvider("awssecrets", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringProvider, error) {
+		return awssecrets.New(l, provider, awsLogLevel), nil
+	})
+	registry.RegisterStringProvider("awskms", func(_ *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringProvider, error) {
+		return awskms.New(provider, awsLogLevel), nil
+	})
+}

--- a/pkg/stringprovider/register_azure.go
+++ b/pkg/stringprovider/register_azure.go
@@ -1,0 +1,16 @@
+//go:build azure || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/azurekeyvault"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("azurekeyvault", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return azurekeyvault.New(provider), nil
+	})
+}

--- a/pkg/stringprovider/register_conjur.go
+++ b/pkg/stringprovider/register_conjur.go
@@ -1,0 +1,16 @@
+//go:build conjur || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/conjur"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("conjur", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return conjur.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_doppler.go
+++ b/pkg/stringprovider/register_doppler.go
@@ -1,0 +1,16 @@
+//go:build doppler || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/doppler"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("doppler", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return doppler.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_gcp.go
+++ b/pkg/stringprovider/register_gcp.go
@@ -1,0 +1,24 @@
+//go:build gcp || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/gcpsecrets"
+	"github.com/helmfile/vals/pkg/providers/gcs"
+	"github.com/helmfile/vals/pkg/providers/gkms"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("gcs", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return gcs.New(provider), nil
+	})
+	registry.RegisterStringProvider("gcpsecrets", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return gcpsecrets.New(provider), nil
+	})
+	registry.RegisterStringProvider("gkms", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return gkms.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_gitlab.go
+++ b/pkg/stringprovider/register_gitlab.go
@@ -1,0 +1,16 @@
+//go:build gitlab || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/gitlab"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("gitlab", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return gitlab.New(provider), nil
+	})
+}

--- a/pkg/stringprovider/register_hcpvaultsecrets.go
+++ b/pkg/stringprovider/register_hcpvaultsecrets.go
@@ -1,0 +1,16 @@
+//go:build hcpvaultsecrets || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/hcpvaultsecrets"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("hcpvaultsecrets", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return hcpvaultsecrets.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_httpjson.go
+++ b/pkg/stringprovider/register_httpjson.go
@@ -1,0 +1,16 @@
+//go:build httpjson || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/httpjson"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("httpjson", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return httpjson.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_infisical.go
+++ b/pkg/stringprovider/register_infisical.go
@@ -1,0 +1,16 @@
+//go:build infisical || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/infisical"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("infisical", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return infisical.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_k8s.go
+++ b/pkg/stringprovider/register_k8s.go
@@ -1,0 +1,16 @@
+//go:build k8s || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/k8s"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("k8s", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return k8s.New(l, provider)
+	})
+}

--- a/pkg/stringprovider/register_oci.go
+++ b/pkg/stringprovider/register_oci.go
@@ -1,0 +1,16 @@
+//go:build oci || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/oci"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("oci", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return oci.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_onepassword.go
+++ b/pkg/stringprovider/register_onepassword.go
@@ -1,0 +1,20 @@
+//go:build onepassword || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/onepassword"
+	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("onepassword", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return onepassword.New(provider), nil
+	})
+	registry.RegisterStringProvider("onepasswordconnect", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return onepasswordconnect.New(provider), nil
+	})
+}

--- a/pkg/stringprovider/register_pulumi.go
+++ b/pkg/stringprovider/register_pulumi.go
@@ -1,0 +1,16 @@
+//go:build pulumi || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/pulumi"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterStringProvider("pulumistateapi", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return pulumi.New(l, provider, "pulumistateapi"), nil
+	})
+}

--- a/pkg/stringprovider/register_scaleway.go
+++ b/pkg/stringprovider/register_scaleway.go
@@ -1,0 +1,16 @@
+//go:build scaleway || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/scaleway"
+)
+
+func init() {
+	registry.RegisterStringProvider("scaleway", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return scaleway.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/register_secretserver.go
+++ b/pkg/stringprovider/register_secretserver.go
@@ -1,0 +1,16 @@
+//go:build secretserver || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/secretserver"
+)
+
+func init() {
+	registry.RegisterStringProvider("tss", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return secretserver.New(provider)
+	})
+}

--- a/pkg/stringprovider/register_sops.go
+++ b/pkg/stringprovider/register_sops.go
@@ -1,0 +1,16 @@
+//go:build sops || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/sops"
+)
+
+func init() {
+	registry.RegisterStringProvider("sops", func(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringProvider, error) {
+		return sops.New(l, provider, awsLogLevel), nil
+	})
+}

--- a/pkg/stringprovider/register_terraform.go
+++ b/pkg/stringprovider/register_terraform.go
@@ -1,0 +1,31 @@
+//go:build terraform || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/tfstate"
+)
+
+func init() {
+	registry.RegisterStringProvider("tfstate", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return tfstate.New(provider, ""), nil
+	})
+	registry.RegisterStringProvider("tfstategs", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return tfstate.New(provider, "gs"), nil
+	})
+	registry.RegisterStringProvider("tfstates3", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return tfstate.New(provider, "s3"), nil
+	})
+	registry.RegisterStringProvider("tfstateazurerm", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return tfstate.New(provider, "azurerm"), nil
+	})
+	registry.RegisterStringProvider("tfstateremote", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return tfstate.New(provider, "remote"), nil
+	})
+	registry.RegisterStringProvider("tfstategitlab", func(_ *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return tfstate.New(provider, "gitlab"), nil
+	})
+}

--- a/pkg/stringprovider/register_vault.go
+++ b/pkg/stringprovider/register_vault.go
@@ -1,0 +1,16 @@
+//go:build vault || all_providers || !custom_providers
+
+package stringprovider
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/vault"
+)
+
+func init() {
+	registry.RegisterStringProvider("vault", func(l *log.Logger, provider api.StaticConfig, _ string) (api.LazyLoadedStringProvider, error) {
+		return vault.New(l, provider), nil
+	})
+}

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -5,97 +5,20 @@ import (
 
 	"github.com/helmfile/vals/pkg/api"
 	"github.com/helmfile/vals/pkg/log"
-	"github.com/helmfile/vals/pkg/providers/awskms"
-	"github.com/helmfile/vals/pkg/providers/awssecrets"
-	"github.com/helmfile/vals/pkg/providers/azurekeyvault"
-	"github.com/helmfile/vals/pkg/providers/conjur"
-	"github.com/helmfile/vals/pkg/providers/doppler"
 	execprovider "github.com/helmfile/vals/pkg/providers/exec"
-	"github.com/helmfile/vals/pkg/providers/gcpsecrets"
-	"github.com/helmfile/vals/pkg/providers/gcs"
-	"github.com/helmfile/vals/pkg/providers/gitlab"
-	"github.com/helmfile/vals/pkg/providers/gkms"
-	"github.com/helmfile/vals/pkg/providers/hcpvaultsecrets"
-	"github.com/helmfile/vals/pkg/providers/httpjson"
-	"github.com/helmfile/vals/pkg/providers/infisical"
-	"github.com/helmfile/vals/pkg/providers/k8s"
-	"github.com/helmfile/vals/pkg/providers/oci"
-	"github.com/helmfile/vals/pkg/providers/onepassword"
-	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
-	"github.com/helmfile/vals/pkg/providers/pulumi"
-	"github.com/helmfile/vals/pkg/providers/s3"
-	"github.com/helmfile/vals/pkg/providers/scaleway"
-	"github.com/helmfile/vals/pkg/providers/secretserver"
-	"github.com/helmfile/vals/pkg/providers/sops"
-	"github.com/helmfile/vals/pkg/providers/ssm"
-	"github.com/helmfile/vals/pkg/providers/tfstate"
-	"github.com/helmfile/vals/pkg/providers/vault"
+	"github.com/helmfile/vals/pkg/providers/registry"
 )
 
 func New(l *log.Logger, provider api.StaticConfig, awsLogLevel string) (api.LazyLoadedStringProvider, error) {
 	tpe := provider.String("name")
 
 	switch tpe {
-	case "s3":
-		return s3.New(l, provider, awsLogLevel), nil
-	case "gcs":
-		return gcs.New(provider), nil
-	case "ssm":
-		return ssm.New(l, provider, awsLogLevel), nil
-	case "vault":
-		return vault.New(l, provider), nil
-	case "awskms":
-		return awskms.New(provider, awsLogLevel), nil
-	case "awssecrets":
-		return awssecrets.New(l, provider, awsLogLevel), nil
-	case "sops":
-		return sops.New(l, provider, awsLogLevel), nil
-	case "gcpsecrets":
-		return gcpsecrets.New(provider), nil
-	case "tfstate":
-		return tfstate.New(provider, ""), nil
-	case "tfstategs":
-		return tfstate.New(provider, "gs"), nil
-	case "tfstates3":
-		return tfstate.New(provider, "s3"), nil
-	case "tfstateazurerm":
-		return tfstate.New(provider, "azurerm"), nil
-	case "tfstateremote":
-		return tfstate.New(provider, "remote"), nil
-	case "tfstategitlab":
-		return tfstate.New(provider, "gitlab"), nil
-	case "azurekeyvault":
-		return azurekeyvault.New(provider), nil
-	case "gitlab":
-		return gitlab.New(provider), nil
-	case "oci":
-		return oci.New(l, provider), nil
-	case "onepassword":
-		return onepassword.New(provider), nil
-	case "onepasswordconnect":
-		return onepasswordconnect.New(provider), nil
-	case "doppler":
-		return doppler.New(l, provider), nil
-	case "pulumistateapi":
-		return pulumi.New(l, provider, "pulumistateapi"), nil
-	case "gkms":
-		return gkms.New(l, provider), nil
-	case "k8s":
-		return k8s.New(l, provider)
-	case "conjur":
-		return conjur.New(l, provider), nil
-	case "hcpvaultsecrets":
-		return hcpvaultsecrets.New(l, provider), nil
-	case "httpjson":
-		return httpjson.New(l, provider), nil
-	case "scaleway":
-		return scaleway.New(l, provider), nil
-	case "tss":
-		return secretserver.New(provider)
-	case "infisical":
-		return infisical.New(l, provider), nil
 	case "exec":
 		return execprovider.New(l, provider), nil
+	default:
+		if factory, ok := registry.GetStringProvider(tpe); ok {
+			return factory(l, provider, awsLogLevel)
+		}
 	}
 
 	return nil, fmt.Errorf("failed initializing string provider from config: %v", provider)

--- a/register_aws.go
+++ b/register_aws.go
@@ -1,0 +1,29 @@
+//go:build aws || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/awskms"
+	"github.com/helmfile/vals/pkg/providers/awssecrets"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/s3"
+	"github.com/helmfile/vals/pkg/providers/ssm"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderS3, func(l *log.Logger, conf config.MapConfig, awsLogLevel string) (api.Provider, error) {
+		return s3.New(l, conf, awsLogLevel), nil
+	})
+	registry.RegisterProvider(ProviderSSM, func(l *log.Logger, conf config.MapConfig, awsLogLevel string) (api.Provider, error) {
+		return ssm.New(l, conf, awsLogLevel), nil
+	})
+	registry.RegisterProvider(ProviderSecretsManager, func(l *log.Logger, conf config.MapConfig, awsLogLevel string) (api.Provider, error) {
+		return awssecrets.New(l, conf, awsLogLevel), nil
+	})
+	registry.RegisterProvider(ProviderKms, func(_ *log.Logger, conf config.MapConfig, awsLogLevel string) (api.Provider, error) {
+		return awskms.New(conf, awsLogLevel), nil
+	})
+}

--- a/register_azure.go
+++ b/register_azure.go
@@ -1,0 +1,17 @@
+//go:build azure || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/azurekeyvault"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderAzureKeyVault, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return azurekeyvault.New(conf), nil
+	})
+}

--- a/register_bitwarden.go
+++ b/register_bitwarden.go
@@ -1,0 +1,17 @@
+//go:build bitwarden || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/bitwarden"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderBitwarden, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return bitwarden.New(l, conf), nil
+	})
+}

--- a/register_conjur.go
+++ b/register_conjur.go
@@ -1,0 +1,17 @@
+//go:build conjur || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/conjur"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderConjur, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return conjur.New(l, conf), nil
+	})
+}

--- a/register_doppler.go
+++ b/register_doppler.go
@@ -1,0 +1,17 @@
+//go:build doppler || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/doppler"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderDoppler, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return doppler.New(l, conf), nil
+	})
+}

--- a/register_gcp.go
+++ b/register_gcp.go
@@ -1,0 +1,29 @@
+//go:build gcp || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/gcpsecrets"
+	"github.com/helmfile/vals/pkg/providers/gcs"
+	"github.com/helmfile/vals/pkg/providers/gkms"
+	"github.com/helmfile/vals/pkg/providers/googlesheets"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderGCS, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return gcs.New(conf), nil
+	})
+	registry.RegisterProvider(ProviderGCPSecretManager, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return gcpsecrets.New(conf), nil
+	})
+	registry.RegisterProvider(ProviderGKMS, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return gkms.New(l, conf), nil
+	})
+	registry.RegisterProvider(ProviderGoogleSheets, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return googlesheets.New(conf), nil
+	})
+}

--- a/register_gitlab.go
+++ b/register_gitlab.go
@@ -1,0 +1,17 @@
+//go:build gitlab || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/gitlab"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderGitLab, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return gitlab.New(conf), nil
+	})
+}

--- a/register_hcpvaultsecrets.go
+++ b/register_hcpvaultsecrets.go
@@ -1,0 +1,17 @@
+//go:build hcpvaultsecrets || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/hcpvaultsecrets"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderHCPVaultSecrets, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return hcpvaultsecrets.New(l, conf), nil
+	})
+}

--- a/register_httpjson.go
+++ b/register_httpjson.go
@@ -1,0 +1,17 @@
+//go:build httpjson || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/httpjson"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderHttpJsonManager, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return httpjson.New(l, conf), nil
+	})
+}

--- a/register_infisical.go
+++ b/register_infisical.go
@@ -1,0 +1,17 @@
+//go:build infisical || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/infisical"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderInfisical, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return infisical.New(l, conf), nil
+	})
+}

--- a/register_k8s.go
+++ b/register_k8s.go
@@ -1,0 +1,17 @@
+//go:build k8s || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/k8s"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderK8s, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return k8s.New(l, conf)
+	})
+}

--- a/register_keychain.go
+++ b/register_keychain.go
@@ -1,0 +1,17 @@
+//go:build keychain || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/keychain"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderKeychain, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return keychain.New(conf), nil
+	})
+}

--- a/register_oci.go
+++ b/register_oci.go
@@ -1,0 +1,17 @@
+//go:build oci || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/oci"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderOCI, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return oci.New(l, conf), nil
+	})
+}

--- a/register_onepassword.go
+++ b/register_onepassword.go
@@ -1,0 +1,21 @@
+//go:build onepassword || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/onepassword"
+	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderOnePassword, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return onepassword.New(conf), nil
+	})
+	registry.RegisterProvider(ProviderOnePasswordConnect, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return onepasswordconnect.New(conf), nil
+	})
+}

--- a/register_openbao.go
+++ b/register_openbao.go
@@ -1,0 +1,17 @@
+//go:build openbao || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/openbao"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderOpenBao, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return openbao.New(l, conf), nil
+	})
+}

--- a/register_pulumi.go
+++ b/register_pulumi.go
@@ -1,0 +1,17 @@
+//go:build pulumi || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/pulumi"
+	"github.com/helmfile/vals/pkg/providers/registry"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderPulumiStateAPI, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return pulumi.New(l, conf, "pulumistateapi"), nil
+	})
+}

--- a/register_scaleway.go
+++ b/register_scaleway.go
@@ -1,0 +1,17 @@
+//go:build scaleway || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/scaleway"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderScaleway, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return scaleway.New(l, conf), nil
+	})
+}

--- a/register_secretserver.go
+++ b/register_secretserver.go
@@ -1,0 +1,17 @@
+//go:build secretserver || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/secretserver"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderSecretserver, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return secretserver.New(conf)
+	})
+}

--- a/register_servercore.go
+++ b/register_servercore.go
@@ -1,0 +1,17 @@
+//go:build servercore || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/servercore"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderServercore, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return servercore.New(l, conf), nil
+	})
+}

--- a/register_sops.go
+++ b/register_sops.go
@@ -1,0 +1,17 @@
+//go:build sops || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/sops"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderSOPS, func(l *log.Logger, conf config.MapConfig, awsLogLevel string) (api.Provider, error) {
+		return sops.New(l, conf, awsLogLevel), nil
+	})
+}

--- a/register_terraform.go
+++ b/register_terraform.go
@@ -1,0 +1,32 @@
+//go:build terraform || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/tfstate"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderTFState, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return tfstate.New(conf, ""), nil
+	})
+	registry.RegisterProvider(ProviderTFStateGS, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return tfstate.New(conf, "gs"), nil
+	})
+	registry.RegisterProvider(ProviderTFStateS3, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return tfstate.New(conf, "s3"), nil
+	})
+	registry.RegisterProvider(ProviderTFStateAzureRM, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return tfstate.New(conf, "azurerm"), nil
+	})
+	registry.RegisterProvider(ProviderTFStateRemote, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return tfstate.New(conf, "remote"), nil
+	})
+	registry.RegisterProvider(ProviderTFStateGitLab, func(_ *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return tfstate.New(conf, "gitlab"), nil
+	})
+}

--- a/register_vault.go
+++ b/register_vault.go
@@ -1,0 +1,17 @@
+//go:build vault || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/vault"
+)
+
+func init() {
+	registry.RegisterProvider(ProviderVault, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
+		return vault.New(l, conf), nil
+	})
+}

--- a/register_yclockbox.go
+++ b/register_yclockbox.go
@@ -1,0 +1,17 @@
+//go:build yandex || all_providers || !custom_providers
+
+package vals
+
+import (
+	"github.com/helmfile/vals/pkg/api"
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+	"github.com/helmfile/vals/pkg/providers/registry"
+	"github.com/helmfile/vals/pkg/providers/yclockbox"
+)
+
+func init() {
+	registry.Register(ProviderLockbox, func(l *log.Logger, conf config.MapConfig) (api.Provider, error) {
+		return yclockbox.New(l, conf), nil
+	})
+}

--- a/register_yclockbox.go
+++ b/register_yclockbox.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registry.Register(ProviderLockbox, func(l *log.Logger, conf config.MapConfig) (api.Provider, error) {
+	registry.RegisterProvider(ProviderLockbox, func(l *log.Logger, conf config.MapConfig, _ string) (api.Provider, error) {
 		return yclockbox.New(l, conf), nil
 	})
 }

--- a/register_yclockbox_noop.go
+++ b/register_yclockbox_noop.go
@@ -1,3 +1,0 @@
-//go:build custom_providers && !yandex && !all_providers
-
-package vals

--- a/register_yclockbox_noop.go
+++ b/register_yclockbox_noop.go
@@ -1,0 +1,3 @@
+//go:build custom_providers && !yandex && !all_providers
+
+package vals

--- a/vals.go
+++ b/vals.go
@@ -52,8 +52,8 @@ import (
 	"github.com/helmfile/vals/pkg/providers/sops"
 	"github.com/helmfile/vals/pkg/providers/ssm"
 	"github.com/helmfile/vals/pkg/providers/tfstate"
+	"github.com/helmfile/vals/pkg/providers/registry"
 	"github.com/helmfile/vals/pkg/providers/vault"
-	"github.com/helmfile/vals/pkg/providers/yclockbox"
 	"github.com/helmfile/vals/pkg/stringmapprovider"
 	"github.com/helmfile/vals/pkg/stringprovider"
 )
@@ -303,9 +303,6 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 		case ProviderBitwarden:
 			p := bitwarden.New(r.logger, conf)
 			return p, nil
-		case ProviderLockbox:
-			p := yclockbox.New(r.logger, conf)
-			return p, nil
 		case ProviderScaleway:
 			p := scaleway.New(r.logger, conf)
 			return p, nil
@@ -320,8 +317,12 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 		case ProviderExec:
 			p := execprovider.New(r.logger, conf)
 			return p, nil
+		default:
+			if factory, ok := registry.Get(scheme); ok {
+				return factory(r.logger, conf)
+			}
+			return nil, fmt.Errorf("no provider registered for scheme %q", scheme)
 		}
-		return nil, fmt.Errorf("no provider registered for scheme %q", scheme)
 	}
 
 	updateProviders := func(uri *url.URL, hash string) (api.Provider, error) {

--- a/vals.go
+++ b/vals.go
@@ -20,40 +20,11 @@ import (
 	"github.com/helmfile/vals/pkg/config"
 	"github.com/helmfile/vals/pkg/expansion"
 	"github.com/helmfile/vals/pkg/log"
-	"github.com/helmfile/vals/pkg/providers/awskms"
-	"github.com/helmfile/vals/pkg/providers/awssecrets"
-	"github.com/helmfile/vals/pkg/providers/azurekeyvault"
-	"github.com/helmfile/vals/pkg/providers/bitwarden"
-	"github.com/helmfile/vals/pkg/providers/conjur"
-	"github.com/helmfile/vals/pkg/providers/doppler"
 	"github.com/helmfile/vals/pkg/providers/echo"
 	"github.com/helmfile/vals/pkg/providers/envsubst"
 	execprovider "github.com/helmfile/vals/pkg/providers/exec"
 	"github.com/helmfile/vals/pkg/providers/file"
-	"github.com/helmfile/vals/pkg/providers/gcpsecrets"
-	"github.com/helmfile/vals/pkg/providers/gcs"
-	"github.com/helmfile/vals/pkg/providers/gitlab"
-	"github.com/helmfile/vals/pkg/providers/gkms"
-	"github.com/helmfile/vals/pkg/providers/googlesheets"
-	"github.com/helmfile/vals/pkg/providers/hcpvaultsecrets"
-	"github.com/helmfile/vals/pkg/providers/httpjson"
-	"github.com/helmfile/vals/pkg/providers/infisical"
-	"github.com/helmfile/vals/pkg/providers/k8s"
-	"github.com/helmfile/vals/pkg/providers/keychain"
-	"github.com/helmfile/vals/pkg/providers/oci"
-	"github.com/helmfile/vals/pkg/providers/onepassword"
-	"github.com/helmfile/vals/pkg/providers/onepasswordconnect"
-	"github.com/helmfile/vals/pkg/providers/openbao"
-	"github.com/helmfile/vals/pkg/providers/pulumi"
-	"github.com/helmfile/vals/pkg/providers/s3"
-	"github.com/helmfile/vals/pkg/providers/scaleway"
-	"github.com/helmfile/vals/pkg/providers/secretserver"
-	"github.com/helmfile/vals/pkg/providers/servercore"
-	"github.com/helmfile/vals/pkg/providers/sops"
-	"github.com/helmfile/vals/pkg/providers/ssm"
-	"github.com/helmfile/vals/pkg/providers/tfstate"
 	"github.com/helmfile/vals/pkg/providers/registry"
-	"github.com/helmfile/vals/pkg/providers/vault"
 	"github.com/helmfile/vals/pkg/stringmapprovider"
 	"github.com/helmfile/vals/pkg/stringprovider"
 )
@@ -193,133 +164,17 @@ func (r *Runtime) prepare() (*expansion.ExpandRegexMatch, error) {
 		conf := config.MapConfig{M: m, FallbackFunc: envFallback}
 
 		switch scheme {
-		case ProviderVault:
-			p := vault.New(r.logger, conf)
-			return p, nil
-		case ProviderOpenBao:
-			p := openbao.New(r.logger, conf)
-			return p, nil
-		case ProviderS3:
-			// ref+s3://foo/bar?region=ap-northeast-1#/baz
-			// 1. GetObject for the bucket foo and key bar
-			// 2. Then extracts the value for key baz(=/foo/bar/baz) from the result from step 1.
-			p := s3.New(r.logger, conf, r.Options.AWSLogLevel)
-			return p, nil
-		case ProviderGCS:
-			// vals+gcs://foo/bar?generation=timestamp#/baz
-			// 1. GetObject for the bucket foo and key bar
-			// 2. Then extracts the value for key baz(=/foo/bar/baz) from the result from step 1.
-			p := gcs.New(conf)
-			return p, nil
-		case ProviderGitLab:
-			// vals+gitlab://project/variable#key
-			p := gitlab.New(conf)
-			return p, nil
-		case ProviderSSM:
-			// ref+awsssm://foo/bar?region=ap-northeast-1#/baz
-			// 1. GetParametersByPath for the prefix /foo/bar
-			// 2. Then extracts the value for key baz(=/foo/bar/baz) from the result from step 1.
-			p := ssm.New(r.logger, conf, r.Options.AWSLogLevel)
-			return p, nil
-		case ProviderSecretsManager:
-			// ref+awssecrets://foo/bar?region=ap-northeast-1#/baz
-			// 1. Get secret for key foo/bar, parse it as yaml
-			// 2. Then extracts the value for key baz) from the result from step 1.
-			p := awssecrets.New(r.logger, conf, r.Options.AWSLogLevel)
-			return p, nil
-		case ProviderOCI:
-			p := oci.New(r.logger, conf)
-			return p, nil
-		case ProviderSOPS:
-			p := sops.New(r.logger, conf, r.Options.AWSLogLevel)
-			return p, nil
 		case ProviderEcho:
-			p := echo.New(conf)
-			return p, nil
+			return echo.New(conf), nil
 		case ProviderFile:
-			p := file.New(conf)
-			return p, nil
-		case ProviderGCPSecretManager:
-			p := gcpsecrets.New(conf)
-			return p, nil
-		case ProviderGoogleSheets:
-			return googlesheets.New(conf), nil
-		case ProviderTFState:
-			p := tfstate.New(conf, "")
-			return p, nil
-		case ProviderTFStateGS:
-			p := tfstate.New(conf, "gs")
-			return p, nil
-		case ProviderTFStateS3:
-			p := tfstate.New(conf, "s3")
-			return p, nil
-		case ProviderTFStateAzureRM:
-			p := tfstate.New(conf, "azurerm")
-			return p, nil
-		case ProviderTFStateRemote:
-			p := tfstate.New(conf, "remote")
-			return p, nil
-		case ProviderTFStateGitLab:
-			p := tfstate.New(conf, "gitlab")
-			return p, nil
-		case ProviderAzureKeyVault:
-			p := azurekeyvault.New(conf)
-			return p, nil
-		case ProviderKms:
-			p := awskms.New(conf, r.Options.AWSLogLevel)
-			return p, nil
-		case ProviderKeychain:
-			p := keychain.New(conf)
-			return p, nil
+			return file.New(conf), nil
 		case ProviderEnvSubst:
-			p := envsubst.New(conf)
-			return p, nil
-		case ProviderOnePassword:
-			p := onepassword.New(conf)
-			return p, nil
-		case ProviderOnePasswordConnect:
-			p := onepasswordconnect.New(conf)
-			return p, nil
-		case ProviderDoppler:
-			p := doppler.New(r.logger, conf)
-			return p, nil
-		case ProviderPulumiStateAPI:
-			p := pulumi.New(r.logger, conf, "pulumistateapi")
-			return p, nil
-		case ProviderGKMS:
-			p := gkms.New(r.logger, conf)
-			return p, nil
-		case ProviderK8s:
-			return k8s.New(r.logger, conf)
-		case ProviderConjur:
-			p := conjur.New(r.logger, conf)
-			return p, nil
-		case ProviderHCPVaultSecrets:
-			p := hcpvaultsecrets.New(r.logger, conf)
-			return p, nil
-		case ProviderHttpJsonManager:
-			p := httpjson.New(r.logger, conf)
-			return p, nil
-		case ProviderBitwarden:
-			p := bitwarden.New(r.logger, conf)
-			return p, nil
-		case ProviderScaleway:
-			p := scaleway.New(r.logger, conf)
-			return p, nil
-		case ProviderSecretserver:
-			return secretserver.New(conf)
-		case ProviderInfisical:
-			p := infisical.New(r.logger, conf)
-			return p, nil
-		case ProviderServercore:
-			p := servercore.New(r.logger, conf)
-			return p, nil
+			return envsubst.New(conf), nil
 		case ProviderExec:
-			p := execprovider.New(r.logger, conf)
-			return p, nil
+			return execprovider.New(r.logger, conf), nil
 		default:
-			if factory, ok := registry.Get(scheme); ok {
-				return factory(r.logger, conf)
+			if factory, ok := registry.GetProvider(scheme); ok {
+				return factory(r.logger, conf, r.Options.AWSLogLevel)
 			}
 			return nil, fmt.Errorf("no provider registered for scheme %q", scheme)
 		}


### PR DESCRIPTION
## Summary

- Introduce a provider registry and Go build tags so that heavy providers can be excluded at compile time
- Make the Yandex Cloud (`yclockbox`) provider optional as the first candidate — its SDK + transitive deps (gRPC stubs, envoyproxy, etc.) are the largest contributor to binary size
- Add CI step to verify minimal build keeps compiling

## Impact

| Build | Stripped size | Change |
|---|---|---|
| Default (all providers) | 140 MB | — |
| `-tags custom_providers` | 98 MB | **−42 MB (−30%)** |

## Usage

```bash
go build ./cmd/vals                                   # all providers (unchanged)
go build -tags custom_providers ./cmd/vals            # exclude optional providers
go build -tags "custom_providers,yandex" ./cmd/vals   # opt-in yclockbox
go build -tags all_providers ./cmd/vals               # explicitly all
```

## How it works

  - pkg/providers/registry — a simple map-based provider registry with Register() / Get()
  - register_yclockbox.go (//go:build yandex || all_providers || !custom_providers) — registers the provider via init()
  - register_yclockbox_noop.go (//go:build custom_providers && !yandex && !all_providers) — empty stub
  - vals.go — the createProvider switch now falls back to the registry for optional providers
  - The same pattern can be applied to other heavy providers (1Password, K8s, etc.) in follow-up PRs

## Test plan

  - go build ./... — full build compiles as before
  - go build -tags custom_providers ./... — minimal build compiles without yclockbox
  - go test ./... — no new test failures in either mode
  - CI step added to verify minimal build on every PR

## See also

* https://github.com/yandex-cloud/go-sdk/issues/42. It would be nice if yclockbox binary size could be reduced as well
  
  Fixes https://github.com/helmfile/vals/issues/1054