### PR TITLE
[sops] Allow encode=base64 config for sops provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ Examples:
 - `ref+sops://<base64>?key_type=base64` reads `<base64>` as the base64-encoded data to be decrypted by sops as `binary`
 - `ref+sops://path/to/file#/foo/bar` reads `path/to/file` as a `yaml` file and returns the value at `foo.bar`.
 - `ref+sops://path/to/file?format=json#/foo/bar` reads `path/to/file` as a `json` file and returns the value at `foo.bar`.
-- `ref+sops://path/to/file?encode=base64` reads `path/to/file`, decrypts it, and returns its whole content encoded as a base64 string (useful for e.g. `config.env` files consumed by Helm charts)
+- `ref+sops://path/to/file?encode=base64` reads `path/to/file` and returns the decrypted content encoded as a base64 string
 
 ### Keychain
 

--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ $ echo 'foo: ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtu
 
 ### SOPS
 
-- The whole content of a SOPS-encrypted file: `ref+sops://base64_data_or_path_to_file?key_type=[filepath|base64]&format=[binary|dotenv|yaml]`
+- The whole content of a SOPS-encrypted file: `ref+sops://base64_data_or_path_to_file?key_type=[filepath|base64]&format=[binary|dotenv|yaml]&encode=[raw|base64]`
 - The value for the specific path in an encrypted YAML/JSON document: `ref+sops://base64_data_or_path_to_file#/json_or_yaml_key/in/the_encrypted_doc`
 
 Note: When using an inline base64-encoded sops "file", be sure to use URL-safe Base64 encoding.
@@ -751,6 +751,7 @@ Examples:
 - `ref+sops://<base64>?key_type=base64` reads `<base64>` as the base64-encoded data to be decrypted by sops as `binary`
 - `ref+sops://path/to/file#/foo/bar` reads `path/to/file` as a `yaml` file and returns the value at `foo.bar`.
 - `ref+sops://path/to/file?format=json#/foo/bar` reads `path/to/file` as a `json` file and returns the value at `foo.bar`.
+- `ref+sops://path/to/file?encode=base64` reads `path/to/file`, decrypts it, and returns its whole content encoded as a base64 string (useful for e.g. `config.env` files consumed by Helm charts)
 
 ### Keychain
 

--- a/pkg/providers/sops/sops.go
+++ b/pkg/providers/sops/sops.go
@@ -24,6 +24,7 @@ import (
 type provider struct {
 	log *log.Logger
 
+	Encode string
 	// KeyType is either "filepath"(default) or "base64".
 	KeyType string
 	// Format is --input-type of sops
@@ -38,6 +39,10 @@ type provider struct {
 func New(l *log.Logger, cfg api.StaticConfig, awsLogLevel string) *provider {
 	p := &provider{
 		log: l,
+	}
+	p.Encode = cfg.String("encode")
+	if p.Encode == "" {
+		p.Encode = "raw"
 	}
 	p.Format = cfg.String("format")
 	p.KeyType = cfg.String("key_type")
@@ -60,7 +65,14 @@ func (p *provider) GetString(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(cleartext), nil
+	switch p.Encode {
+	case "raw":
+		return string(cleartext), nil
+	case "base64":
+		return base64.StdEncoding.EncodeToString(cleartext), nil
+	default:
+		return "", fmt.Errorf("Unsupported encode parameter: '%s'.", p.Encode)
+	}
 }
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {

--- a/pkg/providers/sops/sops.go
+++ b/pkg/providers/sops/sops.go
@@ -24,6 +24,8 @@ import (
 type provider struct {
 	log *log.Logger
 
+	// Encode is the output encoding of the decrypted content: "raw" (default) or "base64".
+	// It applies only to GetString (whole-content reads), not to GetStringMap (fragment reads).
 	Encode string
 	// KeyType is either "filepath"(default) or "base64".
 	KeyType string

--- a/pkg/providers/sops/sops_test.go
+++ b/pkg/providers/sops/sops_test.go
@@ -238,6 +238,30 @@ func TestNewProviderDefaultKeyType(t *testing.T) {
 	}
 }
 
+func TestNewProviderDefaultEncode(t *testing.T) {
+	cfg := config.MapConfig{M: map[string]interface{}{}}
+
+	p := New(log.New(log.Config{}), cfg, "")
+
+	if p.Encode != "raw" {
+		t.Errorf("Encode = %q, want %q (default)", p.Encode, "raw")
+	}
+}
+
+func TestNewProviderReadsEncodeBase64(t *testing.T) {
+	cfg := config.MapConfig{
+		M: map[string]interface{}{
+			"encode": "base64",
+		},
+	}
+
+	p := New(log.New(log.Config{}), cfg, "")
+
+	if p.Encode != "base64" {
+		t.Errorf("Encode = %q, want %q", p.Encode, "base64")
+	}
+}
+
 // staticCredProvider is a no-op aws.CredentialsProvider used in tests.
 type staticCredProvider struct{}
 

--- a/pkg/providers/sops/sops_test.go
+++ b/pkg/providers/sops/sops_test.go
@@ -2,9 +2,22 @@ package sops
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	filippoage "filippo.io/age"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/aes"
+	sopsage "github.com/getsops/sops/v3/age"
+	"github.com/getsops/sops/v3/cmd/sops/common"
+	"github.com/getsops/sops/v3/cmd/sops/formats"
+	sopsconfig "github.com/getsops/sops/v3/config"
 	"github.com/getsops/sops/v3/keyservice"
 
 	"github.com/helmfile/vals/pkg/config"
@@ -259,6 +272,104 @@ func TestNewProviderReadsEncodeBase64(t *testing.T) {
 
 	if p.Encode != "base64" {
 		t.Errorf("Encode = %q, want %q", p.Encode, "base64")
+	}
+}
+
+// newAgeEncryptedSOPSFile encrypts branches with a fresh age key and writes
+// the resulting SOPS file to path. The SOPS_AGE_KEY env var is set so that the
+// provider's key service can decrypt it in-process.
+func newAgeEncryptedSOPSFile(t *testing.T, path string, branches sops.TreeBranches) {
+	t.Helper()
+
+	identity, err := filippoage.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("failed to generate age identity: %v", err)
+	}
+	t.Setenv("SOPS_AGE_KEY", identity.String())
+
+	dataKey := make([]byte, 32)
+	if _, err := rand.Read(dataKey); err != nil {
+		t.Fatalf("failed to generate data key: %v", err)
+	}
+
+	masterKey := &sopsage.MasterKey{Recipient: identity.Recipient().String()}
+	if err := masterKey.Encrypt(dataKey); err != nil {
+		t.Fatalf("failed to encrypt data key with age: %v", err)
+	}
+
+	tree := sops.Tree{
+		Branches: branches,
+		Metadata: sops.Metadata{
+			KeyGroups: []sops.KeyGroup{{masterKey}},
+			Version:   "3.13.2",
+		},
+		FilePath: path,
+	}
+
+	cipher := aes.NewCipher()
+	mac, err := tree.Encrypt(dataKey, cipher)
+	if err != nil {
+		t.Fatalf("failed to encrypt tree: %v", err)
+	}
+	tree.Metadata.LastModified = time.Now().UTC()
+	tree.Metadata.MessageAuthenticationCode, err = cipher.Encrypt(mac, dataKey, tree.Metadata.LastModified.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("failed to encrypt MAC: %v", err)
+	}
+
+	store := common.StoreForFormat(formats.FormatForPath(path), sopsconfig.NewStoresConfig())
+	encrypted, err := store.EmitEncryptedFile(tree)
+	if err != nil {
+		t.Fatalf("failed to emit encrypted file: %v", err)
+	}
+	if err := os.WriteFile(path, encrypted, 0o600); err != nil {
+		t.Fatalf("failed to write encrypted file: %v", err)
+	}
+}
+
+// TestGetStringEncode verifies the encode config option end to end: a real
+// age-encrypted SOPS file is decrypted by the provider and returned either as
+// raw text (default) or as a base64-encoded string.
+func TestGetStringEncode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.yaml")
+
+	newAgeEncryptedSOPSFile(t, path, sops.TreeBranches{
+		sops.TreeBranch{
+			{Key: "foo", Value: "bar"},
+		},
+	})
+
+	newProvider := func(encode string) *provider {
+		var cfg config.MapConfig
+		if encode == "" {
+			cfg = config.MapConfig{M: map[string]interface{}{}}
+		} else {
+			cfg = config.MapConfig{M: map[string]interface{}{"encode": encode}}
+		}
+		return New(log.New(log.Config{}), cfg, "")
+	}
+
+	raw, err := newProvider("").GetString(path)
+	if err != nil {
+		t.Fatalf("GetString with default encode failed: %v", err)
+	}
+	if !strings.Contains(raw, "foo: bar") {
+		t.Errorf("raw output = %q, want it to contain %q", raw, "foo: bar")
+	}
+
+	got, err := newProvider("base64").GetString(path)
+	if err != nil {
+		t.Fatalf("GetString with encode=base64 failed: %v", err)
+	}
+	if want := base64.StdEncoding.EncodeToString([]byte(raw)); got != want {
+		t.Errorf("GetString with encode=base64 = %q, want %q", got, want)
+	}
+
+	if _, err := newProvider("bogus").GetString(path); err == nil {
+		t.Error("GetString with encode=bogus: expected error, got nil")
+	} else if !strings.Contains(err.Error(), "Unsupported encode parameter") {
+		t.Errorf("GetString with encode=bogus: unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
When referencing a sops secret, allow vals tu return it as a base64 encoded string

```
data:
  config.env: ref+sops://config/config.enc.env?encode=base64
```

the results is a base64 encoded string of the decrypted `config/config.enc.env` file.

It's like issue https://github.com/helmfile/vals/issues/163 but for sops provider.