### PR TITLE
feat(vault,openbao): support base64 decode via decode=base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Please see [pkg/providers](https://github.com/helmfile/vals/tree/master/pkg/prov
 * `role_id` defaults to the value of the `VAULT_ROLE_ID` envvar.
 * `secret_id` defaults to the value of the `VAULT_SECRET_ID` envvar.
 * `version` is the specific version of the secret to be obtained. Used when you want to get a previous content of the secret.
-* `encode` controls how the retrieved value is decoded. Defaults to `raw`. Set to `base64` to base64-decode the stored value before returning it (useful when storing binary data such as certificates).
+* `decode` controls how the retrieved value is transformed before being returned. Defaults to `raw` (no transformation). Set to `base64` to base64-decode the stored value (useful when binary data such as certificates is stored as a base64 string).
 
 ### Authentication
 
@@ -368,7 +368,7 @@ Examples:
 * `role_id` defaults to the value of the `BAO_ROLE_ID` envvar.
 * `secret_id` defaults to the value of the `BAO_SECRET_ID` envvar.
 * `version` is the specific version of the secret to be obtained. Used when you want to get a previous content of the secret.
-* `encode` controls how the retrieved value is decoded. Defaults to `raw`. Set to `base64` to base64-decode the stored value before returning it (useful when storing binary data such as certificates).
+* `decode` controls how the retrieved value is transformed before being returned. Defaults to `raw` (no transformation). Set to `base64` to base64-decode the stored value (useful when binary data such as certificates is stored as a base64 string).
 
 The `auth_method` or `BAO_AUTH_METHOD` envvar configures how `vals` authenticates to OpenBao. The following methods are supported:
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Please see [pkg/providers](https://github.com/helmfile/vals/tree/master/pkg/prov
 * `role_id` defaults to the value of the `VAULT_ROLE_ID` envvar.
 * `secret_id` defaults to the value of the `VAULT_SECRET_ID` envvar.
 * `version` is the specific version of the secret to be obtained. Used when you want to get a previous content of the secret.
+* `encode` controls how the retrieved value is decoded. Defaults to `raw`. Set to `base64` to base64-decode the stored value before returning it (useful when storing binary data such as certificates).
 
 ### Authentication
 
@@ -367,6 +368,7 @@ Examples:
 * `role_id` defaults to the value of the `BAO_ROLE_ID` envvar.
 * `secret_id` defaults to the value of the `BAO_SECRET_ID` envvar.
 * `version` is the specific version of the secret to be obtained. Used when you want to get a previous content of the secret.
+* `encode` controls how the retrieved value is decoded. Defaults to `raw`. Set to `base64` to base64-decode the stored value before returning it (useful when storing binary data such as certificates).
 
 The `auth_method` or `BAO_AUTH_METHOD` envvar configures how `vals` authenticates to OpenBao. The following methods are supported:
 

--- a/pkg/providers/openbao/openbao.go
+++ b/pkg/providers/openbao/openbao.go
@@ -42,7 +42,7 @@ type provider struct {
 	PasswordEnv  string
 	PasswordFile string
 	Version      string
-	Encode       string
+	Decode       string
 }
 
 func New(l *log.Logger, cfg api.StaticConfig) *provider {
@@ -106,9 +106,9 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.PasswordFile = os.Getenv("BAO_PASSWORD_FILE")
 	}
 	p.Version = cfg.String("version")
-	p.Encode = cfg.String("encode")
-	if p.Encode == "" {
-		p.Encode = "raw"
+	p.Decode = cfg.String("decode")
+	if p.Decode == "" {
+		p.Decode = "raw"
 	}
 
 	return p
@@ -184,15 +184,15 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		res[k] = v
 	}
 
-	if err := p.applyEncode(res); err != nil {
+	if err := p.applyDecode(res); err != nil {
 		return nil, err
 	}
 
 	return res, nil
 }
 
-func (p *provider) applyEncode(m map[string]interface{}) error {
-	switch p.Encode {
+func (p *provider) applyDecode(m map[string]interface{}) error {
+	switch p.Decode {
 	case "", "raw":
 		return nil
 	case "base64":
@@ -203,13 +203,13 @@ func (p *provider) applyEncode(m map[string]interface{}) error {
 			}
 			decoded, err := base64.StdEncoding.DecodeString(s)
 			if err != nil {
-				return fmt.Errorf("openbao: base64 decode failed for key %q: %v", k, err)
+				return fmt.Errorf("openbao: base64 decode failed for key %q: %w", k, err)
 			}
 			m[k] = string(decoded)
 		}
 		return nil
 	default:
-		return fmt.Errorf("openbao: unsupported encode parameter: %q", p.Encode)
+		return fmt.Errorf("openbao: unsupported decode parameter: %q", p.Decode)
 	}
 }
 

--- a/pkg/providers/openbao/openbao.go
+++ b/pkg/providers/openbao/openbao.go
@@ -1,6 +1,7 @@
 package openbao
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -41,6 +42,7 @@ type provider struct {
 	PasswordEnv  string
 	PasswordFile string
 	Version      string
+	Encode       string
 }
 
 func New(l *log.Logger, cfg api.StaticConfig) *provider {
@@ -104,6 +106,10 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.PasswordFile = os.Getenv("BAO_PASSWORD_FILE")
 	}
 	p.Version = cfg.String("version")
+	p.Encode = cfg.String("encode")
+	if p.Encode == "" {
+		p.Encode = "raw"
+	}
 
 	return p
 }
@@ -178,7 +184,33 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		res[k] = v
 	}
 
+	if err := p.applyEncode(res); err != nil {
+		return nil, err
+	}
+
 	return res, nil
+}
+
+func (p *provider) applyEncode(m map[string]interface{}) error {
+	switch p.Encode {
+	case "", "raw":
+		return nil
+	case "base64":
+		for k, v := range m {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			decoded, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return fmt.Errorf("openbao: base64 decode failed for key %q: %v", k, err)
+			}
+			m[k] = string(decoded)
+		}
+		return nil
+	default:
+		return fmt.Errorf("openbao: unsupported encode parameter: %q", p.Encode)
+	}
 }
 
 func (p *provider) ensureClient() (*openbao.Client, error) {

--- a/pkg/providers/openbao/openbao.go
+++ b/pkg/providers/openbao/openbao.go
@@ -129,11 +129,27 @@ func (p *provider) GetString(key string) (string, error) {
 
 	for k, v := range secret {
 		if k == key {
-			return fmt.Sprintf("%v", v), nil
+			s := fmt.Sprintf("%v", v)
+			return p.decodeString(key, s)
 		}
 	}
 
 	return "", fmt.Errorf("openbao: get string: key %q does not exist in %q", key, path)
+}
+
+func (p *provider) decodeString(key, s string) (string, error) {
+	switch p.Decode {
+	case "", "raw":
+		return s, nil
+	case "base64":
+		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return "", fmt.Errorf("openbao: base64 decode failed for key %q: %w", key, err)
+		}
+		return string(decoded), nil
+	default:
+		return "", fmt.Errorf("openbao: unsupported decode parameter: %q", p.Decode)
+	}
 }
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
@@ -184,33 +200,7 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		res[k] = v
 	}
 
-	if err := p.applyDecode(res); err != nil {
-		return nil, err
-	}
-
 	return res, nil
-}
-
-func (p *provider) applyDecode(m map[string]interface{}) error {
-	switch p.Decode {
-	case "", "raw":
-		return nil
-	case "base64":
-		for k, v := range m {
-			s, ok := v.(string)
-			if !ok {
-				continue
-			}
-			decoded, err := base64.StdEncoding.DecodeString(s)
-			if err != nil {
-				return fmt.Errorf("openbao: base64 decode failed for key %q: %w", k, err)
-			}
-			m[k] = string(decoded)
-		}
-		return nil
-	default:
-		return fmt.Errorf("openbao: unsupported decode parameter: %q", p.Decode)
-	}
 }
 
 func (p *provider) ensureClient() (*openbao.Client, error) {

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -42,7 +42,7 @@ type provider struct {
 	PasswordEnv  string
 	PasswordFile string
 	Version      string
-	Encode       string
+	Decode       string
 }
 
 func New(l *log.Logger, cfg api.StaticConfig) *provider {
@@ -106,9 +106,9 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.PasswordFile = os.Getenv("VAULT_PASSWORD_FILE")
 	}
 	p.Version = cfg.String("version")
-	p.Encode = cfg.String("encode")
-	if p.Encode == "" {
-		p.Encode = "raw"
+	p.Decode = cfg.String("decode")
+	if p.Decode == "" {
+		p.Decode = "raw"
 	}
 
 	return p
@@ -184,15 +184,15 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		res[k] = v
 	}
 
-	if err := p.applyEncode(res); err != nil {
+	if err := p.applyDecode(res); err != nil {
 		return nil, err
 	}
 
 	return res, nil
 }
 
-func (p *provider) applyEncode(m map[string]interface{}) error {
-	switch p.Encode {
+func (p *provider) applyDecode(m map[string]interface{}) error {
+	switch p.Decode {
 	case "", "raw":
 		return nil
 	case "base64":
@@ -203,13 +203,13 @@ func (p *provider) applyEncode(m map[string]interface{}) error {
 			}
 			decoded, err := base64.StdEncoding.DecodeString(s)
 			if err != nil {
-				return fmt.Errorf("vault: base64 decode failed for key %q: %v", k, err)
+				return fmt.Errorf("vault: base64 decode failed for key %q: %w", k, err)
 			}
 			m[k] = string(decoded)
 		}
 		return nil
 	default:
-		return fmt.Errorf("vault: unsupported encode parameter: %q", p.Encode)
+		return fmt.Errorf("vault: unsupported decode parameter: %q", p.Decode)
 	}
 }
 

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -129,11 +129,27 @@ func (p *provider) GetString(key string) (string, error) {
 
 	for k, v := range secret {
 		if k == key {
-			return fmt.Sprintf("%v", v), nil
+			s := fmt.Sprintf("%v", v)
+			return p.decodeString(key, s)
 		}
 	}
 
 	return "", fmt.Errorf("vault: get string: key %q does not exist in %q", key, path)
+}
+
+func (p *provider) decodeString(key, s string) (string, error) {
+	switch p.Decode {
+	case "", "raw":
+		return s, nil
+	case "base64":
+		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return "", fmt.Errorf("vault: base64 decode failed for key %q: %w", key, err)
+		}
+		return string(decoded), nil
+	default:
+		return "", fmt.Errorf("vault: unsupported decode parameter: %q", p.Decode)
+	}
 }
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
@@ -184,33 +200,7 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		res[k] = v
 	}
 
-	if err := p.applyDecode(res); err != nil {
-		return nil, err
-	}
-
 	return res, nil
-}
-
-func (p *provider) applyDecode(m map[string]interface{}) error {
-	switch p.Decode {
-	case "", "raw":
-		return nil
-	case "base64":
-		for k, v := range m {
-			s, ok := v.(string)
-			if !ok {
-				continue
-			}
-			decoded, err := base64.StdEncoding.DecodeString(s)
-			if err != nil {
-				return fmt.Errorf("vault: base64 decode failed for key %q: %w", k, err)
-			}
-			m[k] = string(decoded)
-		}
-		return nil
-	default:
-		return fmt.Errorf("vault: unsupported decode parameter: %q", p.Decode)
-	}
 }
 
 func (p *provider) ensureClient() (*vault.Client, error) {

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -41,6 +42,7 @@ type provider struct {
 	PasswordEnv  string
 	PasswordFile string
 	Version      string
+	Encode       string
 }
 
 func New(l *log.Logger, cfg api.StaticConfig) *provider {
@@ -104,6 +106,10 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.PasswordFile = os.Getenv("VAULT_PASSWORD_FILE")
 	}
 	p.Version = cfg.String("version")
+	p.Encode = cfg.String("encode")
+	if p.Encode == "" {
+		p.Encode = "raw"
+	}
 
 	return p
 }
@@ -178,7 +184,33 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		res[k] = v
 	}
 
+	if err := p.applyEncode(res); err != nil {
+		return nil, err
+	}
+
 	return res, nil
+}
+
+func (p *provider) applyEncode(m map[string]interface{}) error {
+	switch p.Encode {
+	case "", "raw":
+		return nil
+	case "base64":
+		for k, v := range m {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			decoded, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return fmt.Errorf("vault: base64 decode failed for key %q: %v", k, err)
+			}
+			m[k] = string(decoded)
+		}
+		return nil
+	default:
+		return fmt.Errorf("vault: unsupported encode parameter: %q", p.Encode)
+	}
 }
 
 func (p *provider) ensureClient() (*vault.Client, error) {

--- a/vals_openbao_test.go
+++ b/vals_openbao_test.go
@@ -2,9 +2,11 @@ package vals
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -173,6 +175,78 @@ func TestValues_OpenBao_EvalTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValues_OpenBao_Decode_Base64(t *testing.T) {
+	if os.Getenv("SKIP_TESTS") != "" {
+		t.Skip("Skipping tests")
+	}
+
+	plain := "hello-binary-payload"
+	encoded := base64.StdEncoding.EncodeToString([]byte(plain))
+
+	addr, stop := SetupOpenBaoKV(
+		t,
+		map[string]map[string]interface{}{
+			"mykv/bin": {
+				"cert":  encoded,
+				"plain": "not-base64-value",
+			},
+		},
+	)
+	defer stop()
+
+	t.Run("decode=base64 decodes targeted key", func(t *testing.T) {
+		config := map[string]interface{}{
+			"cert": fmt.Sprintf("ref+openbao://mykv/bin?address=%s&decode=base64#/cert", addr),
+		}
+		got, err := Eval(config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["cert"] != plain {
+			t.Errorf("expected decoded value %q, got %q", plain, got["cert"])
+		}
+	})
+
+	t.Run("decode=base64 on non-base64 value returns error", func(t *testing.T) {
+		config := map[string]interface{}{
+			"bad": fmt.Sprintf("ref+openbao://mykv/bin?address=%s&decode=base64#/plain", addr),
+		}
+		_, err := Eval(config)
+		if err == nil {
+			t.Fatalf("expected base64 decode error, got nil")
+		}
+		if !strings.Contains(err.Error(), "base64 decode failed") {
+			t.Errorf("expected base64 decode failure in error, got: %v", err)
+		}
+	})
+
+	t.Run("mixed secret with #/field does not break sibling non-base64 keys", func(t *testing.T) {
+		config := map[string]interface{}{
+			"cert": fmt.Sprintf("ref+openbao://mykv/bin?address=%s&decode=base64#/cert", addr),
+		}
+		got, err := Eval(config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["cert"] != plain {
+			t.Errorf("expected decoded value %q, got %q", plain, got["cert"])
+		}
+	})
+
+	t.Run("no decode parameter returns raw value", func(t *testing.T) {
+		config := map[string]interface{}{
+			"raw": fmt.Sprintf("ref+openbao://mykv/bin?address=%s#/cert", addr),
+		}
+		got, err := Eval(config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["raw"] != encoded {
+			t.Errorf("expected raw value %q, got %q", encoded, got["raw"])
+		}
+	})
 }
 
 func TestValues_OpenBao_String(t *testing.T) {

--- a/vals_vault_test.go
+++ b/vals_vault_test.go
@@ -2,9 +2,11 @@ package vals
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -168,6 +170,78 @@ func TestValues_Vault_EvalTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValues_Vault_Decode_Base64(t *testing.T) {
+	if os.Getenv("SKIP_TESTS") != "" {
+		t.Skip("Skipping tests")
+	}
+
+	plain := "hello-binary-payload"
+	encoded := base64.StdEncoding.EncodeToString([]byte(plain))
+
+	addr, stop := SetupVaultKV(
+		t,
+		map[string]map[string]interface{}{
+			"mykv/bin": {
+				"cert":  encoded,
+				"plain": "not-base64-value",
+			},
+		},
+	)
+	defer stop()
+
+	t.Run("decode=base64 decodes targeted key", func(t *testing.T) {
+		config := map[string]interface{}{
+			"cert": fmt.Sprintf("ref+vault://mykv/bin?address=%s&decode=base64#/cert", addr),
+		}
+		got, err := Eval(config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["cert"] != plain {
+			t.Errorf("expected decoded value %q, got %q", plain, got["cert"])
+		}
+	})
+
+	t.Run("decode=base64 on non-base64 value returns error", func(t *testing.T) {
+		config := map[string]interface{}{
+			"bad": fmt.Sprintf("ref+vault://mykv/bin?address=%s&decode=base64#/plain", addr),
+		}
+		_, err := Eval(config)
+		if err == nil {
+			t.Fatalf("expected base64 decode error, got nil")
+		}
+		if !strings.Contains(err.Error(), "base64 decode failed") {
+			t.Errorf("expected base64 decode failure in error, got: %v", err)
+		}
+	})
+
+	t.Run("mixed secret with #/field does not break sibling non-base64 keys", func(t *testing.T) {
+		config := map[string]interface{}{
+			"cert": fmt.Sprintf("ref+vault://mykv/bin?address=%s&decode=base64#/cert", addr),
+		}
+		got, err := Eval(config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["cert"] != plain {
+			t.Errorf("expected decoded value %q, got %q", plain, got["cert"])
+		}
+	})
+
+	t.Run("no decode parameter returns raw value", func(t *testing.T) {
+		config := map[string]interface{}{
+			"raw": fmt.Sprintf("ref+vault://mykv/bin?address=%s#/cert", addr),
+		}
+		got, err := Eval(config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["raw"] != encoded {
+			t.Errorf("expected raw value %q, got %q", encoded, got["raw"])
+		}
+	})
 }
 
 func TestValues_Vault_String(t *testing.T) {


### PR DESCRIPTION
Adds a `decode` option to the Vault and OpenBao providers. When `decode=base64` is set in the URI query, string values returned via `GetString` are base64-decoded before being substituted. Useful when storing binary payloads (certificates, keystores) as base64 strings in the secret backend.

Decoding is applied only to the specific key returned by `GetString` (e.g. with `#/field` usage); `GetStringMap` is left untouched so secrets containing mixed (non-base64) string fields are not broken.