### PR TITLE
Feat/vault provider cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -33,8 +33,11 @@ type provider struct { //nolint:govet // fieldalignment: unsafe.Sizeof confirms 
 	// kvVersionCache caches isKVv2 preflight results per mount path so each
 	// mount only costs one Vault API call per provider lifetime. Mount KV
 	// versions are immutable at runtime, so the cache never needs clearing.
-	// mu protects kvVersionCache for concurrent callers (e.g. vals-operator).
+	// secretMapCache caches GetStringMap results so multiple keys under the
+	// same path cost only one Vault read per provider lifetime.
+	// mu protects both caches for concurrent callers (e.g. vals-operator).
 	kvVersionCache map[string]kvVersionResult
+	secretMapCache map[string]map[string]interface{}
 	mu             sync.Mutex
 
 	Address      string
@@ -124,6 +127,7 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.Decode = "raw"
 	}
 	p.kvVersionCache = make(map[string]kvVersionResult)
+	p.secretMapCache = make(map[string]map[string]interface{})
 
 	return p
 }
@@ -167,20 +171,24 @@ func (p *provider) decodeString(key, s string) (string, error) {
 }
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
+	p.mu.Lock()
+	if cachedMap, ok := p.secretMapCache[key]; ok {
+		p.mu.Unlock()
+		return cachedMap, nil
+	}
+	cachedVer, verHit := p.kvVersionCache[key]
+	p.mu.Unlock()
+
 	cli, err := p.ensureClient()
 	if err != nil {
 		return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
 	}
 
-	p.mu.Lock()
-	cached, hit := p.kvVersionCache[key]
-	p.mu.Unlock()
-
 	var mountPath string
 	var v2 bool
-	if hit {
-		mountPath = cached.mountPath
-		v2 = cached.v2
+	if verHit {
+		mountPath = cachedVer.mountPath
+		v2 = cachedVer.v2
 	} else {
 		mountPath, v2, err = isKVv2(key, cli)
 		if err != nil {
@@ -227,6 +235,10 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 	for k, v := range secrets {
 		res[k] = v
 	}
+
+	p.mu.Lock()
+	p.secretMapCache[key] = res
+	p.mu.Unlock()
 
 	return res, nil
 }

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -43,6 +43,18 @@ type provider struct {
 	PasswordFile string
 	Version      string
 	Decode       string
+
+	// kvVersionCache caches isKVv2 preflight results per mount path, so each
+	// mount only costs one Vault API call regardless of how many secrets are read.
+	kvVersionCache map[string]kvVersionResult
+	// secretMapCache caches GetStringMap results per secret path, so multiple
+	// keys under the same path only cost one Vault read.
+	secretMapCache map[string]map[string]interface{}
+}
+
+type kvVersionResult struct {
+	mountPath string
+	v2        bool
 }
 
 func New(l *log.Logger, cfg api.StaticConfig) *provider {
@@ -110,6 +122,8 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 	if p.Decode == "" {
 		p.Decode = "raw"
 	}
+	p.kvVersionCache = make(map[string]kvVersionResult)
+	p.secretMapCache = make(map[string]map[string]interface{})
 
 	return p
 }
@@ -153,30 +167,41 @@ func (p *provider) decodeString(key, s string) (string, error) {
 }
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
+	if cached, ok := p.secretMapCache[key]; ok {
+		return cached, nil
+	}
+
 	cli, err := p.ensureClient()
 	if err != nil {
 		return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
 	}
 
-	mountPath, v2, err := isKVv2(key, cli)
-	if err != nil {
-		return nil, err
+	var mountPath string
+	var v2 bool
+	if cached, ok := p.kvVersionCache[key]; ok {
+		mountPath = cached.mountPath
+		v2 = cached.v2
+	} else {
+		mountPath, v2, err = isKVv2(key, cli)
+		if err != nil {
+			return nil, err
+		}
+		p.kvVersionCache[key] = kvVersionResult{mountPath: mountPath, v2: v2}
 	}
 
+	readKey := key
 	if v2 {
-		key = addPrefixToVKVPath(key, mountPath, "data")
+		readKey = addPrefixToVKVPath(key, mountPath, "data")
 	}
-
-	res := map[string]interface{}{}
 
 	data := map[string][]string{}
 	if p.Version != "" {
 		data["version"] = []string{p.Version}
 	}
 
-	secret, err := cli.Logical().ReadWithData(key, data)
+	secret, err := cli.Logical().ReadWithData(readKey, data)
 	if err != nil {
-		p.log.Debugf("vault: read: key=%q", key)
+		p.log.Debugf("vault: read: key=%q", readKey)
 		return nil, err
 	}
 
@@ -196,9 +221,12 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		}
 	}
 
+	res := make(map[string]interface{}, len(secrets))
 	for k, v := range secrets {
 		res[k] = v
 	}
+
+	p.secretMapCache[key] = res
 
 	return res, nil
 }

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	vault "github.com/hashicorp/vault/api"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/helmfile/vals/pkg/api"
 	"github.com/helmfile/vals/pkg/log"
@@ -26,19 +27,20 @@ const (
 // $ vault secrets enable -path mykv kv
 //
 //	Success! Enabled the kv secrets engine at: mykv/
-type provider struct { //nolint:govet // fieldalignment: unsafe.Sizeof confirms no padding waste; tool reports a false discrepancy
+type provider struct {
 	client *vault.Client
 	log    *log.Logger
 
-	// kvVersionCache caches isKVv2 preflight results per mount path so each
-	// mount only costs one Vault API call per provider lifetime. Mount KV
-	// versions are immutable at runtime, so the cache never needs clearing.
-	// secretMapCache caches GetStringMap results so multiple keys under the
-	// same path cost only one Vault read per provider lifetime.
-	// mu protects both caches for concurrent callers (e.g. vals-operator).
+	// kvVersionCache caches isKVv2 preflight results keyed by mount path. Mount
+	// KV versions are immutable at runtime, so the cache never needs clearing
+	// and every secret under a mount shares a single preflight.
 	kvVersionCache map[string]kvVersionResult
-	secretMapCache map[string]map[string]interface{}
-	mu             sync.Mutex
+	// sfVersion dedupes concurrent isKVv2 preflights for the same path so a
+	// burst of first-time callers triggers a single Vault request.
+	sfVersion singleflight.Group
+	// sfRead dedupes concurrent secret reads for the same path so N concurrent
+	// callers cost one Vault read (one token use) instead of N.
+	sfRead singleflight.Group
 
 	Address      string
 	Namespace    string
@@ -54,6 +56,12 @@ type provider struct { //nolint:govet // fieldalignment: unsafe.Sizeof confirms 
 	PasswordFile string
 	Version      string
 	Decode       string
+
+	// mu protects kvVersionCache for concurrent callers (e.g. vals-operator).
+	mu sync.Mutex
+	// clientMu serializes lazy client creation/authentication so concurrent
+	// first callers don't race while building p.client.
+	clientMu sync.Mutex
 }
 
 type kvVersionResult struct {
@@ -127,7 +135,6 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.Decode = "raw"
 	}
 	p.kvVersionCache = make(map[string]kvVersionResult)
-	p.secretMapCache = make(map[string]map[string]interface{})
 
 	return p
 }
@@ -171,32 +178,39 @@ func (p *provider) decodeString(key, s string) (string, error) {
 }
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
-	p.mu.Lock()
-	if cachedMap, ok := p.secretMapCache[key]; ok {
-		p.mu.Unlock()
-		return cachedMap, nil
+	// singleflight collapses a burst of concurrent reads for the same path into
+	// a single Vault read, so vals-operator's parallel callers spend one token
+	// use instead of one per goroutine (#1204). Reads are not cached between
+	// calls, so rotated secrets are always picked up on the next read.
+	v, err, _ := p.sfRead.Do(key, func() (interface{}, error) {
+		return p.readSecretMap(key)
+	})
+	if err != nil {
+		return nil, err
 	}
-	cachedVer, verHit := p.kvVersionCache[key]
-	p.mu.Unlock()
 
+	// The singleflight result is shared by reference among all callers in the
+	// flight; return a per-caller copy so a caller mutating the map can't
+	// corrupt another caller's view.
+	secrets := v.(map[string]interface{})
+	res := make(map[string]interface{}, len(secrets))
+	for k, val := range secrets {
+		res[k] = val
+	}
+
+	return res, nil
+}
+
+// readSecretMap performs a single, uncached Vault read for key.
+func (p *provider) readSecretMap(key string) (map[string]interface{}, error) {
 	cli, err := p.ensureClient()
 	if err != nil {
 		return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
 	}
 
-	var mountPath string
-	var v2 bool
-	if verHit {
-		mountPath = cachedVer.mountPath
-		v2 = cachedVer.v2
-	} else {
-		mountPath, v2, err = isKVv2(key, cli)
-		if err != nil {
-			return nil, err
-		}
-		p.mu.Lock()
-		p.kvVersionCache[key] = kvVersionResult{mountPath: mountPath, v2: v2}
-		p.mu.Unlock()
+	mountPath, v2, err := p.resolveKVVersion(key, cli)
+	if err != nil {
+		return nil, err
 	}
 
 	readKey := key
@@ -236,14 +250,79 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		res[k] = v
 	}
 
-	p.mu.Lock()
-	p.secretMapCache[key] = res
-	p.mu.Unlock()
-
 	return res, nil
 }
 
+// resolveKVVersion returns the mount path and KV-v2 flag for key, reusing a
+// cached preflight result for the key's mount when available and otherwise
+// running (and deduping) a single isKVv2 preflight per mount.
+func (p *provider) resolveKVVersion(key string, cli *vault.Client) (string, bool, error) {
+	if res, ok := p.lookupKVVersion(key); ok {
+		return res.mountPath, res.v2, nil
+	}
+
+	v, err, _ := p.sfVersion.Do(key, func() (interface{}, error) {
+		// Another flight may have populated the cache while this one waited.
+		if res, ok := p.lookupKVVersion(key); ok {
+			return res, nil
+		}
+
+		mountPath, v2, err := isKVv2(key, cli)
+		if err != nil {
+			return kvVersionResult{}, err
+		}
+		res := kvVersionResult{mountPath: mountPath, v2: v2}
+
+		// Cache by mount path so sibling secrets under the same mount reuse this
+		// preflight. Fall back to the full key when Vault reports no mount (e.g.
+		// older servers), which still avoids repeat preflights for that path.
+		cacheKey := mountPath
+		if cacheKey == "" {
+			cacheKey = key
+		}
+		p.mu.Lock()
+		p.kvVersionCache[cacheKey] = res
+		p.mu.Unlock()
+
+		return res, nil
+	})
+	if err != nil {
+		return "", false, err
+	}
+
+	res := v.(kvVersionResult)
+	return res.mountPath, res.v2, nil
+}
+
+// lookupKVVersion returns a cached preflight result whose mount covers key.
+func (p *provider) lookupKVVersion(key string) (kvVersionResult, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Exact match (also covers the empty-mount fallback keyed by full path).
+	if res, ok := p.kvVersionCache[key]; ok {
+		return res, true
+	}
+
+	// Otherwise reuse any cached mount that is a prefix of this path so sibling
+	// secrets under the same mount skip the preflight.
+	for mount, res := range p.kvVersionCache {
+		if mount == "" {
+			continue
+		}
+		if key == strings.TrimSuffix(mount, "/") || strings.HasPrefix(key, mount) {
+			return res, true
+		}
+	}
+
+	return kvVersionResult{}, false
+}
+
 func (p *provider) ensureClient() (*vault.Client, error) {
+	// Serialize creation/auth so concurrent first callers don't race building
+	// the client or double-run the login flow (cli.SetToken).
+	p.clientMu.Lock()
+	defer p.clientMu.Unlock()
 	if p.client == nil {
 		cfg := vault.DefaultConfig()
 		if p.Address != "" {

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	vault "github.com/hashicorp/vault/api"
 
@@ -25,9 +26,16 @@ const (
 // $ vault secrets enable -path mykv kv
 //
 //	Success! Enabled the kv secrets engine at: mykv/
-type provider struct {
+type provider struct { //nolint:govet // fieldalignment: unsafe.Sizeof confirms no padding waste; tool reports a false discrepancy
 	client *vault.Client
 	log    *log.Logger
+
+	// kvVersionCache caches isKVv2 preflight results per mount path so each
+	// mount only costs one Vault API call per provider lifetime. Mount KV
+	// versions are immutable at runtime, so the cache never needs clearing.
+	// mu protects kvVersionCache for concurrent callers (e.g. vals-operator).
+	kvVersionCache map[string]kvVersionResult
+	mu             sync.Mutex
 
 	Address      string
 	Namespace    string
@@ -43,13 +51,6 @@ type provider struct {
 	PasswordFile string
 	Version      string
 	Decode       string
-
-	// kvVersionCache caches isKVv2 preflight results per mount path, so each
-	// mount only costs one Vault API call regardless of how many secrets are read.
-	kvVersionCache map[string]kvVersionResult
-	// secretMapCache caches GetStringMap results per secret path, so multiple
-	// keys under the same path only cost one Vault read.
-	secretMapCache map[string]map[string]interface{}
 }
 
 type kvVersionResult struct {
@@ -123,7 +124,6 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 		p.Decode = "raw"
 	}
 	p.kvVersionCache = make(map[string]kvVersionResult)
-	p.secretMapCache = make(map[string]map[string]interface{})
 
 	return p
 }
@@ -167,18 +167,18 @@ func (p *provider) decodeString(key, s string) (string, error) {
 }
 
 func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
-	if cached, ok := p.secretMapCache[key]; ok {
-		return cached, nil
-	}
-
 	cli, err := p.ensureClient()
 	if err != nil {
 		return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
 	}
 
+	p.mu.Lock()
+	cached, hit := p.kvVersionCache[key]
+	p.mu.Unlock()
+
 	var mountPath string
 	var v2 bool
-	if cached, ok := p.kvVersionCache[key]; ok {
+	if hit {
 		mountPath = cached.mountPath
 		v2 = cached.v2
 	} else {
@@ -186,7 +186,9 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+		p.mu.Lock()
 		p.kvVersionCache[key] = kvVersionResult{mountPath: mountPath, v2: v2}
+		p.mu.Unlock()
 	}
 
 	readKey := key
@@ -225,8 +227,6 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 	for k, v := range secrets {
 		res[k] = v
 	}
-
-	p.secretMapCache[key] = res
 
 	return res, nil
 }

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -36,7 +36,11 @@ type provider struct {
 	// and every secret under a mount shares a single preflight.
 	kvVersionCache map[string]kvVersionResult
 	// sfVersion dedupes concurrent isKVv2 preflights for the same path so a
-	// burst of first-time callers triggers a single Vault request.
+	// burst of first-time callers triggers a single Vault request. Note it is
+	// keyed by full path, so a concurrent first-burst of *distinct* sibling
+	// paths under one mount is not deduped (each runs one preflight); the mount
+	// cache then serves every later call. Sequential and same-path-concurrent
+	// access are both deduped to one preflight per mount.
 	sfVersion singleflight.Group
 	// sfRead dedupes concurrent secret reads for the same path so N concurrent
 	// callers cost one Vault read (one token use) instead of N.
@@ -191,7 +195,9 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 
 	// The singleflight result is shared by reference among all callers in the
 	// flight; return a per-caller copy so a caller mutating the map can't
-	// corrupt another caller's view.
+	// corrupt another caller's view. The copy is shallow — nested map/slice
+	// values are still shared — which is fine for the typical string-valued KV
+	// secret.
 	secrets := v.(map[string]interface{})
 	res := make(map[string]interface{}, len(secrets))
 	for k, val := range secrets {
@@ -245,12 +251,9 @@ func (p *provider) readSecretMap(key string) (map[string]interface{}, error) {
 		}
 	}
 
-	res := make(map[string]interface{}, len(secrets))
-	for k, v := range secrets {
-		res[k] = v
-	}
-
-	return res, nil
+	// Return the map directly: GetStringMap owns the per-caller copy, so a
+	// second copy here would be redundant.
+	return secrets, nil
 }
 
 // resolveKVVersion returns the mount path and KV-v2 flag for key, reusing a
@@ -274,11 +277,16 @@ func (p *provider) resolveKVVersion(key string, cli *vault.Client) (string, bool
 		res := kvVersionResult{mountPath: mountPath, v2: v2}
 
 		// Cache by mount path so sibling secrets under the same mount reuse this
-		// preflight. Fall back to the full key when Vault reports no mount (e.g.
-		// older servers), which still avoids repeat preflights for that path.
+		// preflight. Normalize to a trailing slash so the prefix match in
+		// lookupKVVersion is segment-safe (e.g. mount "secret/" never matches
+		// path "secretv2/x"). Fall back to the full key when Vault reports no
+		// mount (e.g. older servers); that entry is matched exactly, never by
+		// prefix, so it still avoids repeat preflights for that path.
 		cacheKey := mountPath
 		if cacheKey == "" {
 			cacheKey = key
+		} else if !strings.HasSuffix(cacheKey, "/") {
+			cacheKey += "/"
 		}
 		p.mu.Lock()
 		p.kvVersionCache[cacheKey] = res
@@ -304,13 +312,17 @@ func (p *provider) lookupKVVersion(key string) (kvVersionResult, bool) {
 		return res, true
 	}
 
-	// Otherwise reuse any cached mount that is a prefix of this path so sibling
-	// secrets under the same mount skip the preflight.
+	// Otherwise reuse any cached mount that covers this path so sibling secrets
+	// under the same mount skip the preflight. Only trailing-slash mount entries
+	// are prefix-matched; empty-mount fallbacks are full secret paths and only
+	// ever match exactly above. Comparing key+"/" against the slash-terminated
+	// mount keeps the match segment-safe ("secret/" matches "secret" and
+	// "secret/foo" but not "secretv2/x").
 	for mount, res := range p.kvVersionCache {
-		if mount == "" {
+		if !strings.HasSuffix(mount, "/") {
 			continue
 		}
-		if key == strings.TrimSuffix(mount, "/") || strings.HasPrefix(key, mount) {
+		if strings.HasPrefix(key+"/", mount) {
 			return res, true
 		}
 	}

--- a/pkg/providers/vault/vault_test.go
+++ b/pkg/providers/vault/vault_test.go
@@ -1,0 +1,179 @@
+package vault
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+)
+
+// fakeVault is a minimal Vault HTTP stub that counts KV-version preflights and
+// secret reads so tests can assert how many API calls (and therefore token
+// uses) a provider makes.
+type fakeVault struct {
+	server *httptest.Server
+	data   map[string]interface{}
+
+	mountPath string
+	version   string // "1" or "2"
+
+	preflights atomic.Int64
+	reads      atomic.Int64
+}
+
+func newFakeVault(t *testing.T, mountPath, version string, data map[string]interface{}) *fakeVault {
+	t.Helper()
+	fv := &fakeVault{mountPath: mountPath, version: version, data: data}
+	fv.server = httptest.NewServer(http.HandlerFunc(fv.handle))
+	t.Cleanup(fv.server.Close)
+	return fv
+}
+
+func (fv *fakeVault) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+
+	if strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts/") {
+		fv.preflights.Add(1)
+		_ = enc.Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"path":    fv.mountPath,
+				"options": map[string]interface{}{"version": fv.version},
+			},
+		})
+		return
+	}
+
+	// Anything else is a secret read. KV v2 nests the payload under data.data.
+	fv.reads.Add(1)
+	payload := fv.data
+	if fv.version == "2" {
+		payload = map[string]interface{}{"data": fv.data}
+	}
+	_ = enc.Encode(map[string]interface{}{"data": payload})
+}
+
+func newTestProvider(t *testing.T, addr string) *provider {
+	t.Helper()
+	// Avoid picking up a developer's real token file/agent during tests.
+	t.Setenv("VAULT_TOKEN", "test-token")
+	cfg := config.MapConfig{M: map[string]interface{}{
+		"address":     addr,
+		"auth_method": "token",
+		"token_env":   "VAULT_TOKEN",
+	}}
+	return New(log.New(log.Config{Output: nil}), cfg)
+}
+
+// TestGetStringMap_ConcurrentDedup asserts that a burst of concurrent callers
+// for the same path collapses to a single preflight and a single read, which is
+// the whole point of the singleflight wiring (#1204).
+func TestGetStringMap_ConcurrentDedup(t *testing.T) {
+	fv := newFakeVault(t, "secret/", "2", map[string]interface{}{"foo": "bar"})
+	p := newTestProvider(t, fv.server.URL)
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	results := make([]map[string]interface{}, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = p.GetStringMap("secret/myapp")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d failed: %v", i, err)
+		}
+		if results[i]["foo"] != "bar" {
+			t.Fatalf("caller %d got %v, want foo=bar", i, results[i])
+		}
+	}
+
+	if got := fv.preflights.Load(); got != 1 {
+		t.Errorf("preflights = %d, want 1", got)
+	}
+	if got := fv.reads.Load(); got != 1 {
+		t.Errorf("reads = %d, want 1", got)
+	}
+}
+
+// TestGetStringMap_ReturnsIndependentCopies guards against returning the shared
+// singleflight map by reference: mutating one caller's result must not leak into
+// another read.
+func TestGetStringMap_ReturnsIndependentCopies(t *testing.T) {
+	fv := newFakeVault(t, "secret/", "2", map[string]interface{}{"foo": "bar"})
+	p := newTestProvider(t, fv.server.URL)
+
+	first, err := p.GetStringMap("secret/myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first["foo"] = "mutated"
+
+	second, err := p.GetStringMap("secret/myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second["foo"] != "bar" {
+		t.Errorf("second read returned mutated value %q, want bar", second["foo"])
+	}
+}
+
+// TestPreflightCachedPerMount asserts that sibling secrets under the same mount
+// reuse a single KV-version preflight, while each read still hits Vault (no
+// stale secret caching).
+func TestPreflightCachedPerMount(t *testing.T) {
+	fv := newFakeVault(t, "secret/", "2", map[string]interface{}{"foo": "bar"})
+	p := newTestProvider(t, fv.server.URL)
+
+	if _, err := p.GetStringMap("secret/app1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.GetStringMap("secret/app2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := fv.preflights.Load(); got != 1 {
+		t.Errorf("preflights = %d, want 1 (one per mount)", got)
+	}
+	if got := fv.reads.Load(); got != 2 {
+		t.Errorf("reads = %d, want 2 (reads are not cached)", got)
+	}
+}
+
+func TestGetString(t *testing.T) {
+	fv := newFakeVault(t, "secret/", "2", map[string]interface{}{"username": "alice"})
+	p := newTestProvider(t, fv.server.URL)
+
+	got, err := p.GetString("secret/myapp/username")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "alice" {
+		t.Errorf("GetString = %q, want alice", got)
+	}
+}
+
+func TestGetStringMap_KVv1(t *testing.T) {
+	fv := newFakeVault(t, "kv/", "1", map[string]interface{}{"foo": "bar"})
+	p := newTestProvider(t, fv.server.URL)
+
+	got, err := p.GetStringMap("kv/myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["foo"] != "bar" {
+		t.Errorf("GetStringMap = %v, want foo=bar", got)
+	}
+}

--- a/pkg/providers/vault/vault_test.go
+++ b/pkg/providers/vault/vault_test.go
@@ -161,14 +161,14 @@ func TestLookupKVVersion_SiblingMountPrefix(t *testing.T) {
 
 	cases := []struct {
 		key      string
+		describe string
 		wantOK   bool
 		wantV2   bool
-		describe string
 	}{
-		{"secret/app", true, true, "child of mount"},
-		{"secret", true, true, "mount root"},
-		{"secretv2/app", false, false, "distinct mount sharing textual prefix"},
-		{"other/app", false, false, "unrelated mount"},
+		{"secret/app", "child of mount", true, true},
+		{"secret", "mount root", true, true},
+		{"secretv2/app", "distinct mount sharing textual prefix", false, false},
+		{"other/app", "unrelated mount", false, false},
 	}
 	for _, tc := range cases {
 		res, ok := p.lookupKVVersion(tc.key)

--- a/pkg/providers/vault/vault_test.go
+++ b/pkg/providers/vault/vault_test.go
@@ -152,6 +152,55 @@ func TestPreflightCachedPerMount(t *testing.T) {
 	}
 }
 
+// TestLookupKVVersion_SiblingMountPrefix locks in the segment-safe prefix match:
+// a cached mount must serve its own children and root but never a textually
+// prefixed but distinct mount (secret/ vs secretv2/).
+func TestLookupKVVersion_SiblingMountPrefix(t *testing.T) {
+	p := newTestProvider(t, "http://127.0.0.1:8200")
+	p.kvVersionCache["secret/"] = kvVersionResult{mountPath: "secret/", v2: true}
+
+	cases := []struct {
+		key      string
+		wantOK   bool
+		wantV2   bool
+		describe string
+	}{
+		{"secret/app", true, true, "child of mount"},
+		{"secret", true, true, "mount root"},
+		{"secretv2/app", false, false, "distinct mount sharing textual prefix"},
+		{"other/app", false, false, "unrelated mount"},
+	}
+	for _, tc := range cases {
+		res, ok := p.lookupKVVersion(tc.key)
+		if ok != tc.wantOK {
+			t.Errorf("%s: lookupKVVersion(%q) ok = %v, want %v", tc.describe, tc.key, ok, tc.wantOK)
+			continue
+		}
+		if ok && res.v2 != tc.wantV2 {
+			t.Errorf("%s: lookupKVVersion(%q) v2 = %v, want %v", tc.describe, tc.key, res.v2, tc.wantV2)
+		}
+	}
+}
+
+// TestPreflightNormalizesMountWithoutSlash proves the cache key is normalized to
+// a trailing slash on insert: a mount reported without one still lets sibling
+// secrets reuse a single preflight via the segment-safe prefix match.
+func TestPreflightNormalizesMountWithoutSlash(t *testing.T) {
+	fv := newFakeVault(t, "secret", "2", map[string]interface{}{"foo": "bar"})
+	p := newTestProvider(t, fv.server.URL)
+
+	if _, err := p.GetStringMap("secret/app1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.GetStringMap("secret/app2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := fv.preflights.Load(); got != 1 {
+		t.Errorf("preflights = %d, want 1 (mount normalized to trailing slash)", got)
+	}
+}
+
 func TestGetString(t *testing.T) {
 	fv := newFakeVault(t, "secret/", "2", map[string]interface{}{"username": "alice"})
 	p := newTestProvider(t, fv.server.URL)


### PR DESCRIPTION
## Summary

- Cache `isKVv2` preflight results, keyed by **mount path**, so every secret under a mount shares a single `GET /v1/sys/internal/ui/mounts/<path>` preflight. Mount KV versions are immutable at runtime, so this cache is safe to keep for the provider's lifetime.
- Dedup concurrent secret reads with `golang.org/x/sync/singleflight`: a burst of parallel callers for the same path (the vals-operator case) collapses into a single `ReadWithData`, spending **one** token use instead of one per goroutine. Reads are **not** cached between calls, so rotated secrets are always picked up on the next read.
- Return a per-caller copy of the secret map (the singleflight result is shared by reference, and `GetStringMap` is a public API).
- Serialize lazy client creation/authentication in `ensureClient` so concurrent first callers don't race while building the client / running the login flow.
- Add concurrency tests against a stubbed Vault server asserting preflight/read call counts and map isolation.

## Motivation

Each secret reference in a `vals`-processed YAML file previously cost **two** Vault API calls:

1. `GET /v1/sys/internal/ui/mounts/<path>` — KV version preflight
2. `ReadWithData` — secret read

For N secrets that meant up to 2N token uses, which breaks Vault tokens created with a low `-use-limit`. The original concern (#1204) is concurrent resolution in [vals-operator](https://github.com/digitalis-io/vals-operator), where N goroutines requesting the same uncached path would each fire the preflight + read.

After this change:

- **Preflight:** one per unique mount (cached for the provider lifetime). Note `sfVersion` is keyed by full path, so a concurrent *first-burst* of distinct sibling paths under one mount can fire one preflight each before the mount cache warms; sequential and same-path-concurrent access dedupe to one per mount.
- **Reads:** concurrent requests for the same path dedup to one; sequential requests still re-read Vault (no stale secrets).

## Why no persistent secret cache

An earlier revision cached `GetStringMap` results for the provider's lifetime. That was dropped: in a long-running operator it would serve **stale** secrets after rotation, with no eviction. `singleflight` delivers the concurrency win the issue actually asks for without the staleness risk.

Closes #1204

