### PR TITLE
Support Terraform State files for authentication against remotes #1219

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,19 @@ which is equivalent to the following input for `vals`:
 $ echo 'foo: ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtual_network.name' | vals eval -f -
 ```
 
+The API token is resolved in the following order of precedence:
+
+1. the `tfe_token` option (via the `providers` config or a `ref+` URL query parameter)
+2. the `TFE_TOKEN` environment variable
+3. the token stored by `terraform login` / `tofu login` in `credentials.tfrc.json`
+
+The credentials file is the one written when you authenticate with `terraform login` or `tofu login`, so no extra setup is needed once you are logged in. It is looked up at `$HOME/.terraform.d/credentials.tfrc.json` (used by both Terraform and OpenTofu) and, when that directory does not exist, at `$XDG_CONFIG_HOME/opentofu/credentials.tfrc.json` (OpenTofu). The token stored for the requested host (e.g. `app.terraform.io`) is used. A non-default location can be pointed at with the `tfe_credentials_file` option.
+
+Examples:
+
+- `ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtual_network.name?tfe_token=xxxx`
+- `ref+tfstateremote://tfe.example.com/myorg/myworkspace/output.virtual_network.name?tfe_credentials_file=/custom/path/credentials.tfrc.json`
+
 ### Terraform in GitLab (tfstategitlab)
 
 - `ref+tfstategitlab://{gitlab_host}/api/v4/projects/{project_id}/terraform/state/{state_name}/RESOURCE_NAME[?gitlab_user=GITLAB_USER&gitlab_token=GITLAB_TOKEN]`

--- a/README.md
+++ b/README.md
@@ -720,7 +720,8 @@ $ echo 'foo: ref+tfstateazurerm://my_rg/my_storage_account/terraform-backend/uni
 
 ### Terraform in Terraform Cloud / Terraform Enterprise (tfstateremote)
 
-- `ref+tfstateremote://app.terraform.io/{org}/{myworkspace}/RESOURCE_NAME[?tfe_token=TFE_TOKEN or tfe_credentials_file=PATH]`
+- `ref+tfstateremote://app.terraform.io/{org}/{myworkspace}/RESOURCE_NAME[?tfe_token=TOKEN]`
+- `ref+tfstateremote://app.terraform.io/{org}/{myworkspace}/RESOURCE_NAME[?tfe_credentials_file=PATH]`
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ $ echo 'foo: ref+tfstateazurerm://my_rg/my_storage_account/terraform-backend/uni
 
 ### Terraform in Terraform Cloud / Terraform Enterprise (tfstateremote)
 
-- `ref+tfstateremote://app.terraform.io/{org}/{myworkspace}/RESOURCE_NAME[?tfe_token=TFE_TOKEN&tfe_credentials_file=PATH]`
+- `ref+tfstateremote://app.terraform.io/{org}/{myworkspace}/RESOURCE_NAME[?tfe_token=TFE_TOKEN or tfe_credentials_file=PATH]`
 
 Examples:
 
@@ -746,7 +746,7 @@ The API token is resolved in the following order of precedence:
 2. the `TFE_TOKEN` environment variable
 3. the token stored by `terraform login` / `tofu login` in `credentials.tfrc.json`
 
-The credentials file is the one written when you authenticate with `terraform login` or `tofu login`, so no extra setup is needed once you are logged in. It is looked up at `$HOME/.terraform.d/credentials.tfrc.json` (used by both Terraform and OpenTofu) and then at `$XDG_CONFIG_HOME/opentofu/credentials.tfrc.json` (used by OpenTofu when `XDG_CONFIG_HOME` is set). The token stored for the requested host (e.g. `app.terraform.io`) is used. A non-default location can be pointed at with the `tfe_credentials_file` option; a configured file that cannot be read or parsed fails with an error.
+The credentials file is read from `$HOME/.terraform.d/credentials.tfrc.json`, then from `$XDG_CONFIG_HOME/opentofu/credentials.tfrc.json`, using the token stored for the requested host (e.g. `app.terraform.io`). A non-default location can be set with the `tfe_credentials_file` option.
 
 ### Terraform in GitLab (tfstategitlab)
 

--- a/README.md
+++ b/README.md
@@ -720,11 +720,13 @@ $ echo 'foo: ref+tfstateazurerm://my_rg/my_storage_account/terraform-backend/uni
 
 ### Terraform in Terraform Cloud / Terraform Enterprise (tfstateremote)
 
-- `ref+tfstateremote://app.terraform.io/{org}/{myworkspace}/RESOURCE_NAME`
+- `ref+tfstateremote://app.terraform.io/{org}/{myworkspace}/RESOURCE_NAME[?tfe_token=TFE_TOKEN&tfe_credentials_file=PATH]`
 
 Examples:
 
 - `ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtual_network.name`
+- `ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtual_network.name?tfe_token=xxxx`
+- `ref+tfstateremote://tfe.example.com/myorg/myworkspace/output.virtual_network.name?tfe_credentials_file=/custom/path/credentials.tfrc.json`
 
 It allows to use Terraform state stored in Terraform Cloud / Terraform Enterprise given the resource group, the organization and the workspace. You can try to read the state with command (with exported variable `TFE_TOKEN`):
 
@@ -744,12 +746,7 @@ The API token is resolved in the following order of precedence:
 2. the `TFE_TOKEN` environment variable
 3. the token stored by `terraform login` / `tofu login` in `credentials.tfrc.json`
 
-The credentials file is the one written when you authenticate with `terraform login` or `tofu login`, so no extra setup is needed once you are logged in. It is looked up at `$HOME/.terraform.d/credentials.tfrc.json` (used by both Terraform and OpenTofu) and, when that directory does not exist, at `$XDG_CONFIG_HOME/opentofu/credentials.tfrc.json` (OpenTofu). The token stored for the requested host (e.g. `app.terraform.io`) is used. A non-default location can be pointed at with the `tfe_credentials_file` option.
-
-Examples:
-
-- `ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtual_network.name?tfe_token=xxxx`
-- `ref+tfstateremote://tfe.example.com/myorg/myworkspace/output.virtual_network.name?tfe_credentials_file=/custom/path/credentials.tfrc.json`
+The credentials file is the one written when you authenticate with `terraform login` or `tofu login`, so no extra setup is needed once you are logged in. It is looked up at `$HOME/.terraform.d/credentials.tfrc.json` (used by both Terraform and OpenTofu) and then at `$XDG_CONFIG_HOME/opentofu/credentials.tfrc.json` (used by OpenTofu when `XDG_CONFIG_HOME` is set). The token stored for the requested host (e.g. `app.terraform.io`) is used. A non-default location can be pointed at with the `tfe_credentials_file` option; a configured file that cannot be read or parsed fails with an error.
 
 ### Terraform in GitLab (tfstategitlab)
 

--- a/pkg/providers/tfstate/credentials.go
+++ b/pkg/providers/tfstate/credentials.go
@@ -1,0 +1,80 @@
+package tfstate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// terraformCredentials mirrors the structure of the credentials file written by
+// `terraform login` and `tofu login` (credentials.tfrc.json):
+//
+//	{"credentials": {"app.terraform.io": {"token": "xxxx.atlasv1.zzzz"}}}
+type terraformCredentials struct {
+	Credentials map[string]struct {
+		Token string `json:"token"`
+	} `json:"credentials"`
+}
+
+// credentialsFileCandidates returns the credentials.tfrc.json locations to
+// probe, in order of precedence. It covers both the Terraform and OpenTofu
+// defaults:
+//
+//   - $HOME/.terraform.d/credentials.tfrc.json (Terraform and OpenTofu default)
+//   - $XDG_CONFIG_HOME/opentofu/credentials.tfrc.json (OpenTofu when the legacy
+//     ~/.terraform.d directory is absent)
+func credentialsFileCandidates() []string {
+	const fileName = "credentials.tfrc.json"
+
+	var candidates []string
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".terraform.d", fileName))
+	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		candidates = append(candidates, filepath.Join(xdg, "opentofu", fileName))
+	}
+	return candidates
+}
+
+// tokenFromCredentialsFile reads the API token for hostname from the first
+// readable Terraform / OpenTofu credentials file (credentials.tfrc.json). When
+// path is non-empty it is used instead of the default candidate locations. It
+// returns an empty string when no file is found or the host has no stored token.
+func tokenFromCredentialsFile(path, hostname string) string {
+	candidates := []string{path}
+	if path == "" {
+		candidates = credentialsFileCandidates()
+	}
+
+	for _, c := range candidates {
+		data, err := os.ReadFile(c)
+		if err != nil {
+			continue
+		}
+		var creds terraformCredentials
+		if err := json.Unmarshal(data, &creds); err != nil {
+			continue
+		}
+		if entry, ok := creds.Credentials[hostname]; ok && entry.Token != "" {
+			return entry.Token
+		}
+	}
+	return ""
+}
+
+// resolveTFEToken resolves the Terraform Cloud / Enterprise API token for
+// hostname used by the "remote" backend. Resolution precedence:
+//
+//  1. the tfe_token provider config option (vals config or ref+ URL query)
+//  2. the TFE_TOKEN environment variable
+//  3. the token stored by `terraform login` / `tofu login` in
+//     credentials.tfrc.json
+func (p *provider) resolveTFEToken(hostname string) string {
+	if p.tfeToken != "" {
+		return p.tfeToken
+	}
+	if token := os.Getenv("TFE_TOKEN"); token != "" {
+		return token
+	}
+	return tokenFromCredentialsFile(p.tfeCredentialsFile, hostname)
+}

--- a/pkg/providers/tfstate/credentials.go
+++ b/pkg/providers/tfstate/credentials.go
@@ -2,8 +2,10 @@ package tfstate
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // terraformCredentials mirrors the structure of the credentials file written by
@@ -21,8 +23,8 @@ type terraformCredentials struct {
 // defaults:
 //
 //   - $HOME/.terraform.d/credentials.tfrc.json (Terraform and OpenTofu default)
-//   - $XDG_CONFIG_HOME/opentofu/credentials.tfrc.json (OpenTofu when the legacy
-//     ~/.terraform.d directory is absent)
+//   - $XDG_CONFIG_HOME/opentofu/credentials.tfrc.json (OpenTofu when
+//     XDG_CONFIG_HOME is set and the legacy ~/.terraform.d directory is absent)
 func credentialsFileCandidates() []string {
 	const fileName = "credentials.tfrc.json"
 
@@ -36,17 +38,29 @@ func credentialsFileCandidates() []string {
 	return candidates
 }
 
-// tokenFromCredentialsFile reads the API token for hostname from the first
-// readable Terraform / OpenTofu credentials file (credentials.tfrc.json). When
-// path is non-empty it is used instead of the default candidate locations. It
-// returns an empty string when no file is found or the host has no stored token.
-func tokenFromCredentialsFile(path, hostname string) string {
-	candidates := []string{path}
-	if path == "" {
-		candidates = credentialsFileCandidates()
+// tokenFromCredentialsFile reads the API token for hostname from a Terraform /
+// OpenTofu credentials file (credentials.tfrc.json). The hostname is lowercased
+// before the lookup, matching the normalized form terraform login stores in the
+// file. When path is non-empty it is used instead of the default candidate
+// locations and must be readable and valid JSON; a default location that is
+// missing or unreadable is silently skipped. It returns an empty string when no
+// file is found or the host has no stored token.
+func tokenFromCredentialsFile(path, hostname string) (string, error) {
+	hostname = strings.ToLower(hostname)
+
+	if path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading tfe_credentials_file: %w", err)
+		}
+		var creds terraformCredentials
+		if err := json.Unmarshal(data, &creds); err != nil {
+			return "", fmt.Errorf("parsing tfe_credentials_file %s: %w", path, err)
+		}
+		return creds.Credentials[hostname].Token, nil
 	}
 
-	for _, c := range candidates {
+	for _, c := range credentialsFileCandidates() {
 		data, err := os.ReadFile(c)
 		if err != nil {
 			continue
@@ -56,10 +70,10 @@ func tokenFromCredentialsFile(path, hostname string) string {
 			continue
 		}
 		if entry, ok := creds.Credentials[hostname]; ok && entry.Token != "" {
-			return entry.Token
+			return entry.Token, nil
 		}
 	}
-	return ""
+	return "", nil
 }
 
 // resolveTFEToken resolves the Terraform Cloud / Enterprise API token for
@@ -69,12 +83,12 @@ func tokenFromCredentialsFile(path, hostname string) string {
 //  2. the TFE_TOKEN environment variable
 //  3. the token stored by `terraform login` / `tofu login` in
 //     credentials.tfrc.json
-func (p *provider) resolveTFEToken(hostname string) string {
+func (p *provider) resolveTFEToken(hostname string) (string, error) {
 	if p.tfeToken != "" {
-		return p.tfeToken
+		return p.tfeToken, nil
 	}
 	if token := os.Getenv("TFE_TOKEN"); token != "" {
-		return token
+		return token, nil
 	}
 	return tokenFromCredentialsFile(p.tfeCredentialsFile, hostname)
 }

--- a/pkg/providers/tfstate/credentials_test.go
+++ b/pkg/providers/tfstate/credentials_test.go
@@ -6,24 +6,41 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/helmfile/vals/pkg/config"
 )
 
 const fakeCredentialsJSON = `{"credentials":{"app.terraform.io":{"token":"filetoken"},"tfe.example.com":{"token":"enterprisetoken"}}}`
 
-func writeCredentialsFile(t *testing.T, content string) string {
+// writeCredentialsFile writes a credentials.tfrc.json with the given content
+// into dir (created if needed) and returns its path.
+func writeCredentialsFile(t *testing.T, dir, content string) string {
 	t.Helper()
-	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(dir, 0o700))
 	path := filepath.Join(dir, "credentials.tfrc.json")
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatalf("writing credentials file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 	return path
 }
 
+// unsetEnv removes key from the environment for the duration of the test.
+// t.Setenv is called first so the original value is restored on cleanup.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	t.Setenv(key, "")
+	require.NoError(t, os.Unsetenv(key))
+}
+
+// setHomeDir points os.UserHomeDir at dir on all platforms (HOME on Unix,
+// USERPROFILE on Windows).
+func setHomeDir(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}
+
 func TestTokenFromCredentialsFile(t *testing.T) {
-	path := writeCredentialsFile(t, fakeCredentialsJSON)
+	path := writeCredentialsFile(t, t.TempDir(), fakeCredentialsJSON)
 
 	tests := []struct {
 		name     string
@@ -33,59 +50,119 @@ func TestTokenFromCredentialsFile(t *testing.T) {
 	}{
 		{name: "default host", path: path, hostname: "app.terraform.io", want: "filetoken"},
 		{name: "enterprise host", path: path, hostname: "tfe.example.com", want: "enterprisetoken"},
+		{name: "mixed-case host is lowercased", path: path, hostname: "App.Terraform.IO", want: "filetoken"},
 		{name: "unknown host", path: path, hostname: "nope.example.com", want: ""},
-		{name: "missing file", path: filepath.Join(t.TempDir(), "absent.json"), hostname: "app.terraform.io", want: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tokenFromCredentialsFile(tt.path, tt.hostname))
+			token, err := tokenFromCredentialsFile(tt.path, tt.hostname)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, token)
 		})
 	}
 }
 
-func TestTokenFromCredentialsFile_InvalidJSON(t *testing.T) {
-	path := writeCredentialsFile(t, "not json")
-	assert.Empty(t, tokenFromCredentialsFile(path, "app.terraform.io"))
+func TestTokenFromCredentialsFile_ExplicitPathErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := tokenFromCredentialsFile(filepath.Join(t.TempDir(), "absent.json"), "app.terraform.io")
+		assert.ErrorContains(t, err, "reading tfe_credentials_file")
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		path := writeCredentialsFile(t, t.TempDir(), "not json")
+		_, err := tokenFromCredentialsFile(path, "app.terraform.io")
+		assert.ErrorContains(t, err, "parsing tfe_credentials_file")
+	})
 }
 
 func TestTokenFromCredentialsFile_DefaultLocation(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDir(t, home)
 	// Ensure the OpenTofu XDG candidate is not accidentally picked up.
-	t.Setenv("XDG_CONFIG_HOME", "")
+	unsetEnv(t, "XDG_CONFIG_HOME")
 
-	credDir := filepath.Join(home, ".terraform.d")
-	if err := os.MkdirAll(credDir, 0o700); err != nil {
-		t.Fatalf("creating credentials dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(credDir, "credentials.tfrc.json"), []byte(fakeCredentialsJSON), 0o600); err != nil {
-		t.Fatalf("writing credentials file: %v", err)
-	}
+	writeCredentialsFile(t, filepath.Join(home, ".terraform.d"), fakeCredentialsJSON)
 
-	assert.Equal(t, "filetoken", tokenFromCredentialsFile("", "app.terraform.io"))
+	token, err := tokenFromCredentialsFile("", "app.terraform.io")
+	require.NoError(t, err)
+	assert.Equal(t, "filetoken", token)
+}
+
+func TestTokenFromCredentialsFile_DefaultLocationMissing(t *testing.T) {
+	setHomeDir(t, t.TempDir())
+	unsetEnv(t, "XDG_CONFIG_HOME")
+
+	token, err := tokenFromCredentialsFile("", "app.terraform.io")
+	require.NoError(t, err)
+	assert.Empty(t, token)
 }
 
 func TestTokenFromCredentialsFile_OpenTofuXDGLocation(t *testing.T) {
 	// OpenTofu falls back to $XDG_CONFIG_HOME/opentofu when ~/.terraform.d is absent.
-	home := t.TempDir()
 	xdg := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDir(t, t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 
-	credDir := filepath.Join(xdg, "opentofu")
-	if err := os.MkdirAll(credDir, 0o700); err != nil {
-		t.Fatalf("creating credentials dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(credDir, "credentials.tfrc.json"), []byte(fakeCredentialsJSON), 0o600); err != nil {
-		t.Fatalf("writing credentials file: %v", err)
+	writeCredentialsFile(t, filepath.Join(xdg, "opentofu"), fakeCredentialsJSON)
+
+	token, err := tokenFromCredentialsFile("", "app.terraform.io")
+	require.NoError(t, err)
+	assert.Equal(t, "filetoken", token)
+}
+
+func TestTokenFromCredentialsFile_TerraformLocationWinsOverXDG(t *testing.T) {
+	home := t.TempDir()
+	xdg := t.TempDir()
+	setHomeDir(t, home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	writeCredentialsFile(t, filepath.Join(home, ".terraform.d"), fakeCredentialsJSON)
+	writeCredentialsFile(t, filepath.Join(xdg, "opentofu"), `{"credentials":{"app.terraform.io":{"token":"xdgtoken"}}}`)
+
+	token, err := tokenFromCredentialsFile("", "app.terraform.io")
+	require.NoError(t, err)
+	assert.Equal(t, "filetoken", token)
+}
+
+func TestTokenFromCredentialsFile_DefaultLocationFallthrough(t *testing.T) {
+	// Unlike an explicit tfe_credentials_file, a default location that is
+	// invalid or has no usable token is silently skipped in favor of the next
+	// candidate.
+	tests := []struct {
+		name        string
+		homeContent string
+	}{
+		{name: "invalid JSON is skipped", homeContent: "not json"},
+		{name: "empty token is skipped", homeContent: `{"credentials":{"app.terraform.io":{"token":""}}}`},
 	}
 
-	assert.Equal(t, "filetoken", tokenFromCredentialsFile("", "app.terraform.io"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			xdg := t.TempDir()
+			setHomeDir(t, home)
+			t.Setenv("XDG_CONFIG_HOME", xdg)
+
+			writeCredentialsFile(t, filepath.Join(home, ".terraform.d"), tt.homeContent)
+			writeCredentialsFile(t, filepath.Join(xdg, "opentofu"), `{"credentials":{"app.terraform.io":{"token":"xdgtoken"}}}`)
+
+			token, err := tokenFromCredentialsFile("", "app.terraform.io")
+			require.NoError(t, err)
+			assert.Equal(t, "xdgtoken", token)
+		})
+	}
 }
 
 func TestResolveTFEToken_Precedence(t *testing.T) {
-	path := writeCredentialsFile(t, fakeCredentialsJSON)
+	path := writeCredentialsFile(t, t.TempDir(), fakeCredentialsJSON)
+
+	resolve := func(t *testing.T, p *provider, hostname string) string {
+		t.Helper()
+		token, err := p.resolveTFEToken(hostname)
+		require.NoError(t, err)
+		return token
+	}
 
 	t.Run("config token wins", func(t *testing.T) {
 		t.Setenv("TFE_TOKEN", "envtoken")
@@ -93,27 +170,41 @@ func TestResolveTFEToken_Precedence(t *testing.T) {
 			"tfe_token":            "cfgtoken",
 			"tfe_credentials_file": path,
 		}}, "remote")
-		assert.Equal(t, "cfgtoken", p.resolveTFEToken("app.terraform.io"))
+		assert.Equal(t, "cfgtoken", resolve(t, p, "app.terraform.io"))
 	})
 
 	t.Run("env token beats file", func(t *testing.T) {
 		t.Setenv("TFE_TOKEN", "envtoken")
 		p := New(config.MapConfig{M: map[string]interface{}{"tfe_credentials_file": path}}, "remote")
-		assert.Equal(t, "envtoken", p.resolveTFEToken("app.terraform.io"))
+		assert.Equal(t, "envtoken", resolve(t, p, "app.terraform.io"))
 	})
 
 	t.Run("file token as last resort", func(t *testing.T) {
-		t.Setenv("TFE_TOKEN", "")
+		unsetEnv(t, "TFE_TOKEN")
 		p := New(config.MapConfig{M: map[string]interface{}{"tfe_credentials_file": path}}, "remote")
-		assert.Equal(t, "filetoken", p.resolveTFEToken("app.terraform.io"))
+		assert.Equal(t, "filetoken", resolve(t, p, "app.terraform.io"))
+	})
+
+	t.Run("hostname is lowercased for the file lookup", func(t *testing.T) {
+		unsetEnv(t, "TFE_TOKEN")
+		p := New(config.MapConfig{M: map[string]interface{}{"tfe_credentials_file": path}}, "remote")
+		assert.Equal(t, "enterprisetoken", resolve(t, p, "TFE.Example.COM"))
 	})
 
 	t.Run("nothing resolves to empty", func(t *testing.T) {
-		t.Setenv("TFE_TOKEN", "")
-		emptyDir := t.TempDir()
-		t.Setenv("HOME", emptyDir)
-		t.Setenv("XDG_CONFIG_HOME", "")
+		unsetEnv(t, "TFE_TOKEN")
+		setHomeDir(t, t.TempDir())
+		unsetEnv(t, "XDG_CONFIG_HOME")
 		p := New(config.MapConfig{M: map[string]interface{}{}}, "remote")
-		assert.Empty(t, p.resolveTFEToken("app.terraform.io"))
+		assert.Empty(t, resolve(t, p, "app.terraform.io"))
+	})
+
+	t.Run("bad explicit credentials file surfaces an error", func(t *testing.T) {
+		unsetEnv(t, "TFE_TOKEN")
+		p := New(config.MapConfig{M: map[string]interface{}{
+			"tfe_credentials_file": filepath.Join(t.TempDir(), "absent.json"),
+		}}, "remote")
+		_, err := p.resolveTFEToken("app.terraform.io")
+		assert.ErrorContains(t, err, "reading tfe_credentials_file")
 	})
 }

--- a/pkg/providers/tfstate/credentials_test.go
+++ b/pkg/providers/tfstate/credentials_test.go
@@ -1,0 +1,119 @@
+package tfstate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/helmfile/vals/pkg/config"
+)
+
+const fakeCredentialsJSON = `{"credentials":{"app.terraform.io":{"token":"filetoken"},"tfe.example.com":{"token":"enterprisetoken"}}}`
+
+func writeCredentialsFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.tfrc.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing credentials file: %v", err)
+	}
+	return path
+}
+
+func TestTokenFromCredentialsFile(t *testing.T) {
+	path := writeCredentialsFile(t, fakeCredentialsJSON)
+
+	tests := []struct {
+		name     string
+		path     string
+		hostname string
+		want     string
+	}{
+		{name: "default host", path: path, hostname: "app.terraform.io", want: "filetoken"},
+		{name: "enterprise host", path: path, hostname: "tfe.example.com", want: "enterprisetoken"},
+		{name: "unknown host", path: path, hostname: "nope.example.com", want: ""},
+		{name: "missing file", path: filepath.Join(t.TempDir(), "absent.json"), hostname: "app.terraform.io", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tokenFromCredentialsFile(tt.path, tt.hostname))
+		})
+	}
+}
+
+func TestTokenFromCredentialsFile_InvalidJSON(t *testing.T) {
+	path := writeCredentialsFile(t, "not json")
+	assert.Empty(t, tokenFromCredentialsFile(path, "app.terraform.io"))
+}
+
+func TestTokenFromCredentialsFile_DefaultLocation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Ensure the OpenTofu XDG candidate is not accidentally picked up.
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	credDir := filepath.Join(home, ".terraform.d")
+	if err := os.MkdirAll(credDir, 0o700); err != nil {
+		t.Fatalf("creating credentials dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(credDir, "credentials.tfrc.json"), []byte(fakeCredentialsJSON), 0o600); err != nil {
+		t.Fatalf("writing credentials file: %v", err)
+	}
+
+	assert.Equal(t, "filetoken", tokenFromCredentialsFile("", "app.terraform.io"))
+}
+
+func TestTokenFromCredentialsFile_OpenTofuXDGLocation(t *testing.T) {
+	// OpenTofu falls back to $XDG_CONFIG_HOME/opentofu when ~/.terraform.d is absent.
+	home := t.TempDir()
+	xdg := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	credDir := filepath.Join(xdg, "opentofu")
+	if err := os.MkdirAll(credDir, 0o700); err != nil {
+		t.Fatalf("creating credentials dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(credDir, "credentials.tfrc.json"), []byte(fakeCredentialsJSON), 0o600); err != nil {
+		t.Fatalf("writing credentials file: %v", err)
+	}
+
+	assert.Equal(t, "filetoken", tokenFromCredentialsFile("", "app.terraform.io"))
+}
+
+func TestResolveTFEToken_Precedence(t *testing.T) {
+	path := writeCredentialsFile(t, fakeCredentialsJSON)
+
+	t.Run("config token wins", func(t *testing.T) {
+		t.Setenv("TFE_TOKEN", "envtoken")
+		p := New(config.MapConfig{M: map[string]interface{}{
+			"tfe_token":            "cfgtoken",
+			"tfe_credentials_file": path,
+		}}, "remote")
+		assert.Equal(t, "cfgtoken", p.resolveTFEToken("app.terraform.io"))
+	})
+
+	t.Run("env token beats file", func(t *testing.T) {
+		t.Setenv("TFE_TOKEN", "envtoken")
+		p := New(config.MapConfig{M: map[string]interface{}{"tfe_credentials_file": path}}, "remote")
+		assert.Equal(t, "envtoken", p.resolveTFEToken("app.terraform.io"))
+	})
+
+	t.Run("file token as last resort", func(t *testing.T) {
+		t.Setenv("TFE_TOKEN", "")
+		p := New(config.MapConfig{M: map[string]interface{}{"tfe_credentials_file": path}}, "remote")
+		assert.Equal(t, "filetoken", p.resolveTFEToken("app.terraform.io"))
+	})
+
+	t.Run("nothing resolves to empty", func(t *testing.T) {
+		t.Setenv("TFE_TOKEN", "")
+		emptyDir := t.TempDir()
+		t.Setenv("HOME", emptyDir)
+		t.Setenv("XDG_CONFIG_HOME", "")
+		p := New(config.MapConfig{M: map[string]interface{}{}}, "remote")
+		assert.Empty(t, p.resolveTFEToken("app.terraform.io"))
+	})
+}

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -115,11 +115,12 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 	// back to the credentials file written by `terraform login` / `tofu login`)
 	// and export it around the read, restoring the previous value afterwards.
 	if p.backend == "remote" {
-		hostname := f
-		if idx := strings.Index(f, "/"); idx >= 0 {
-			hostname = f[:idx]
+		hostname, _, _ := strings.Cut(f, "/")
+		token, err := p.resolveTFEToken(hostname)
+		if err != nil {
+			return nil, err
 		}
-		if token := p.resolveTFEToken(hostname); token != "" {
+		if token != "" {
 			v, wasSet := os.LookupEnv("TFE_TOKEN")
 			if err := os.Setenv("TFE_TOKEN", token); err != nil {
 				return nil, fmt.Errorf("setting TFE_TOKEN envvar: %w", err)

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -115,7 +116,9 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 	// back to the credentials file written by `terraform login` / `tofu login`)
 	// and export it around the read, restoring the previous value afterwards.
 	if p.backend == "remote" {
-		hostname, _, _ := strings.Cut(f, "/")
+		// f is joined with os.PathSeparator in GetString, so normalize it to
+		// forward slashes before extracting the hostname.
+		hostname, _, _ := strings.Cut(filepath.ToSlash(f), "/")
 		token, err := p.resolveTFEToken(hostname)
 		if err != nil {
 			return nil, err

--- a/pkg/providers/tfstate/tfstate.go
+++ b/pkg/providers/tfstate/tfstate.go
@@ -22,12 +22,14 @@ import (
 const gitlabStateHTTPTimeout = 30 * time.Second
 
 type provider struct {
-	backend          string
-	awsProfile       string
-	azSubscriptionId string
-	gitlabUser       string
-	gitlabToken      string
-	gitlabScheme     string
+	backend            string
+	awsProfile         string
+	azSubscriptionId   string
+	gitlabUser         string
+	gitlabToken        string
+	gitlabScheme       string
+	tfeToken           string
+	tfeCredentialsFile string
 }
 
 func New(cfg api.StaticConfig, backend string) *provider {
@@ -38,6 +40,8 @@ func New(cfg api.StaticConfig, backend string) *provider {
 	p.gitlabUser = cfg.String("gitlab_user")
 	p.gitlabToken = cfg.String("gitlab_token")
 	p.gitlabScheme = cfg.String("gitlab_scheme")
+	p.tfeToken = cfg.String("tfe_token")
+	p.tfeCredentialsFile = cfg.String("tfe_credentials_file")
 	return p
 }
 
@@ -104,6 +108,30 @@ func (p *provider) ReadTFState(f, k string) (*tfstate.TFState, error) {
 		defer func() {
 			_ = os.Setenv("AZURE_SUBSCRIPTION_ID", v)
 		}()
+	}
+
+	// tfstate-lookup's "remote" backend reads the Terraform Cloud / Enterprise
+	// token exclusively from the TFE_TOKEN envvar. Resolve the token (falling
+	// back to the credentials file written by `terraform login` / `tofu login`)
+	// and export it around the read, restoring the previous value afterwards.
+	if p.backend == "remote" {
+		hostname := f
+		if idx := strings.Index(f, "/"); idx >= 0 {
+			hostname = f[:idx]
+		}
+		if token := p.resolveTFEToken(hostname); token != "" {
+			v, wasSet := os.LookupEnv("TFE_TOKEN")
+			if err := os.Setenv("TFE_TOKEN", token); err != nil {
+				return nil, fmt.Errorf("setting TFE_TOKEN envvar: %w", err)
+			}
+			defer func() {
+				if wasSet {
+					_ = os.Setenv("TFE_TOKEN", v)
+				} else {
+					_ = os.Unsetenv("TFE_TOKEN")
+				}
+			}()
+		}
 	}
 
 	switch p.backend {


### PR DESCRIPTION
This should resolve https://github.com/helmfile/vals/issues/1219

If I should modify something please comment.

Disclaimer: I used AI to make the changes. However I tested it locally (mac) and reviewed each line. 