### PR TITLE
Fix concurrent map access in azurekeyvault and httpjson providers

### DIFF
--- a/pkg/providers/azurekeyvault/azurekeyvault.go
+++ b/pkg/providers/azurekeyvault/azurekeyvault.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -18,6 +19,10 @@ import (
 type provider struct {
 	// azure key vault client
 	clients map[string]*azsecrets.Client
+	// clientsMu guards the clients map so concurrent callers don't race
+	// while reading or writing it. It is not held during credential and
+	// client creation, so different vaults can initialize in parallel.
+	clientsMu sync.Mutex
 }
 
 func New(cfg api.StaticConfig) *provider {
@@ -59,8 +64,11 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 }
 
 func (p *provider) getClientForKeyVault(vaultBaseURL string) (*azsecrets.Client, error) {
-	if val, ok := p.clients[vaultBaseURL]; val != nil || ok {
-		return p.clients[vaultBaseURL], nil
+	p.clientsMu.Lock()
+	client, ok := p.clients[vaultBaseURL]
+	p.clientsMu.Unlock()
+	if ok && client != nil {
+		return client, nil
 	}
 
 	cred, err := getTokenCredential()
@@ -68,12 +76,21 @@ func (p *provider) getClientForKeyVault(vaultBaseURL string) (*azsecrets.Client,
 		return nil, err
 	}
 
-	p.clients[vaultBaseURL], err = azsecrets.NewClient(vaultBaseURL, cred, nil)
+	client, err = azsecrets.NewClient(vaultBaseURL, cred, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return p.clients[vaultBaseURL], nil
+	// Concurrent callers may have created a client for the same vault in
+	// the meantime, so keep the first stored one as the canonical client.
+	p.clientsMu.Lock()
+	defer p.clientsMu.Unlock()
+	if cached, ok := p.clients[vaultBaseURL]; ok && cached != nil {
+		return cached, nil
+	}
+	p.clients[vaultBaseURL] = client
+
+	return client, nil
 }
 
 func getTokenCredential() (azcore.TokenCredential, error) {

--- a/pkg/providers/azurekeyvault/azurekeyvault_test.go
+++ b/pkg/providers/azurekeyvault/azurekeyvault_test.go
@@ -2,10 +2,37 @@ package azurekeyvault
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func Test_getClientForKeyVault_concurrent(t *testing.T) {
+	// Use the managed identity credential constructor because it doesn't
+	// require external tooling (e.g., Azure CLI) and the test never fetches
+	// a token.
+	t.Setenv("AZKV_AUTH", "managed")
+
+	p := New(nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			vaultBaseURL := fmt.Sprintf("https://test-vault-%d.vault.azure.net", i%10)
+			if _, err := p.getClientForKeyVault(vaultBaseURL); err != nil {
+				t.Errorf("getClientForKeyVault(%q): %v", vaultBaseURL, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if len(p.clients) != 10 {
+		t.Errorf("expected 10 cached clients, got %d", len(p.clients))
+	}
+}
 
 func Test_parseKey(t *testing.T) {
 	testcases := []struct {

--- a/pkg/providers/httpjson/httpjson.go
+++ b/pkg/providers/httpjson/httpjson.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/antchfx/jsonquery"
 	"github.com/antchfx/xpath"
@@ -19,6 +20,10 @@ type provider struct {
 	docs       map[string]*jsonquery.Node
 	protocol   string
 	floatAsInt bool
+	// docsMu guards the docs map so concurrent callers don't race while
+	// reading or writing it. It is not held during document fetching, so
+	// different URLs can be fetched in parallel.
+	docsMu sync.Mutex
 }
 
 func New(l *log.Logger, cfg api.StaticConfig) *provider {
@@ -91,16 +96,34 @@ func GetUrlFromUri(uri string, protocol string) (string, error) {
 }
 
 func (p *provider) GetJsonDoc(url string) error {
-	if _, ok := p.docs[url]; !ok {
-		doc, err := jsonquery.LoadURL(url)
-		if err != nil {
-			return fmt.Errorf("error fetching json document at %v: %v", url, err)
-		}
-		p.log.Debugf("httpjson: successfully retrieved JSON data from: %s", url)
-		p.docs[url] = doc
+	_, err := p.getJsonDoc(url)
+	return err
+}
+
+func (p *provider) getJsonDoc(url string) (*jsonquery.Node, error) {
+	p.docsMu.Lock()
+	doc, ok := p.docs[url]
+	p.docsMu.Unlock()
+	if ok {
+		return doc, nil
 	}
 
-	return nil
+	doc, err := jsonquery.LoadURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching json document at %v: %w", url, err)
+	}
+	p.log.Debugf("httpjson: successfully retrieved JSON data from: %s", url)
+
+	// Concurrent callers may have fetched the same URL in the meantime,
+	// so keep the first stored document as the canonical one.
+	p.docsMu.Lock()
+	defer p.docsMu.Unlock()
+	if cached, ok := p.docs[url]; ok {
+		return cached, nil
+	}
+	p.docs[url] = doc
+
+	return doc, nil
 }
 
 func (p *provider) GetString(uri string) (string, error) {
@@ -108,7 +131,7 @@ func (p *provider) GetString(uri string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = p.GetJsonDoc(url)
+	doc, err := p.getJsonDoc(url)
 	if err != nil {
 		return "", err
 	}
@@ -119,7 +142,7 @@ func (p *provider) GetString(uri string) (string, error) {
 
 	returnValue := ""
 	var values []string
-	node, err := jsonquery.Query(p.docs[url], xpathQuery)
+	node, err := jsonquery.Query(doc, xpathQuery)
 	if err != nil {
 		return "", fmt.Errorf("error querying the xpath expression %s, error: %s", xpathQuery, err)
 	}

--- a/pkg/providers/httpjson/httpjson_test.go
+++ b/pkg/providers/httpjson/httpjson_test.go
@@ -1,0 +1,48 @@
+package httpjson
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/helmfile/vals/pkg/config"
+	"github.com/helmfile/vals/pkg/log"
+)
+
+func Test_GetString_concurrent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"value": %q}`, r.URL.Path)
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	p := New(log.New(log.Config{Output: io.Discard}), config.Map(map[string]interface{}{
+		"insecure": "true",
+	}))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			path := fmt.Sprintf("/doc-%d", i%10)
+			got, err := p.GetString(fmt.Sprintf("httpjson://%s%s#/value", host, path))
+			if err != nil {
+				t.Errorf("GetString(%q): %v", path, err)
+				return
+			}
+			if got != path {
+				t.Errorf("GetString(%q): want %q, got %q", path, path, got)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if len(p.docs) != 10 {
+		t.Errorf("expected 10 cached documents, got %d", len(p.docs))
+	}
+}


### PR DESCRIPTION
Both providers lazily populate an internal cache map (Key Vault clients, fetched JSON documents) without synchronization. When helmfile runs with concurrency > 1, parallel goroutines resolving refs crash the process with 'fatal error: concurrent map writes'. Guard each cache with a mutex that only covers map access. Credential setup and document fetching run outside the lock, so different vaults and URLs can initialize in parallel. Cache stores double-check for entries created concurrently and keep the first one as canonical. Also add regression tests that fail on the unfixed code when run with the Go race detector.

---

Disclaimer: This change was implemented using Claude Fable 5 based on the stack trace that I provided from one of our CI runs where we extensively use the azurekeyvault provider. This issue has been there "forever", but we lived with it by disabling concurrency in Helmfile and accepting the much longer deployment times. The recent developments in AI motivated me to finally find and fix this issue now. I also asked it to find similar issues and it came up with this fix for the httpjson provider as well.