### PR TITLE
feat: add infisical OIDC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1274,7 +1274,7 @@ This provider allows retrieval of secrets from [Infisical](https://infisical.com
 Environment variables:
 
 - `INFISICAL_URL`: the Infisical instance URL, defaults to the SaaS (`https://app.infisical.com`).
-- `INFISICAL_AUTH_METHOD` (required): the authentication method, one of: `UNIVERSAL_AUTH`, `KUBERNETES`, `AWS_IAM`, `AZURE`, `GCP_IAM`, `GCP_ID_TOKEN`.
+- `INFISICAL_AUTH_METHOD` (required): the authentication method, one of: `UNIVERSAL_AUTH`, `KUBERNETES`, `AWS_IAM`, `AZURE`, `GCP_IAM`, `GCP_ID_TOKEN`, `OIDC_AUTH`.
 
 Parameters:
 
@@ -1310,6 +1310,42 @@ Depending on which one is chosen with the `INFISICAL_AUTH_METHOD` environment va
   - `INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH`: the path to your GCP service account key file.
 - **GCP ID Token**: `GCP_ID_TOKEN`
   - `INFISICAL_GCP_AUTH_IDENTITY_ID`: your Infisical Machine Identity ID.
+- **OIDC Auth**: `OIDC_AUTH`
+  - `INFISICAL_OIDC_AUTH_IDENTITY_ID`: your Infisical Machine Identity ID.
+  - `INFISICAL_AUTH_JWT` (or `INFISICAL_JWT`): the OIDC JWT from your identity provider. Obtaining the JWT is the caller's responsibility (any OIDC IdP). Optionally set `INFISICAL_OIDC_AUTH_TOKEN_KEY_NAME` to read the JWT from a different environment variable (defaults to `INFISICAL_AUTH_JWT`).
+
+##### GitHub Actions (OIDC)
+
+Configure a machine identity with [OIDC Auth for GitHub](https://infisical.com/docs/documentation/platform/identities/oidc-auth/github) (discovery URL / issuer `https://token.actions.githubusercontent.com`, plus your bound subject/audiences/claims). The workflow must request an ID token, export it as `INFISICAL_AUTH_JWT`, then run `vals`:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Request OIDC token
+        run: |
+          TOKEN=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/${{ github.repository_owner }}" \
+            | jq -r '.value')
+          echo "::add-mask::$TOKEN"
+          echo "INFISICAL_AUTH_JWT=$TOKEN" >> "$GITHUB_ENV"
+
+      - name: Resolve secrets with vals
+        env:
+          INFISICAL_AUTH_METHOD: OIDC_AUTH
+          INFISICAL_OIDC_AUTH_IDENTITY_ID: ${{ vars.INFISICAL_OIDC_AUTH_IDENTITY_ID }}
+          # Optional: INFISICAL_URL for self-hosted / EU
+        run: vals eval -f refs.yaml
+```
+
+Match the `audience` query parameter to the audiences configured on the Infisical machine identity. `INFISICAL_OIDC_AUTH_IDENTITY_ID` is not secret and can live in repository variables.
 
 ### SecretServer
 

--- a/pkg/providers/infisical/infisical.go
+++ b/pkg/providers/infisical/infisical.go
@@ -83,9 +83,37 @@ func auth(p *provider) error {
 	case util.GCP_ID_TOKEN:
 		// reads INFISICAL_GCP_AUTH_IDENTITY_ID from env
 		_, err = p.client.Auth().GcpIdTokenAuthLogin("")
+	case util.OIDC_AUTH:
+		// reads INFISICAL_OIDC_AUTH_IDENTITY_ID from env; JWT from INFISICAL_AUTH_JWT / INFISICAL_JWT
+		var jwt string
+		jwt, err = oidcJWTFromEnv()
+		if err != nil {
+			return err
+		}
+		_, err = p.client.Auth().OidcAuthLogin("", jwt)
 	}
 
 	return err
+}
+
+// oidcJWTFromEnv resolves the OIDC JWT using Infisical Terraform/CLI conventions.
+// Token env name defaults to INFISICAL_AUTH_JWT, overridable via INFISICAL_OIDC_AUTH_TOKEN_KEY_NAME.
+// Falls back to INFISICAL_JWT for CLI compatibility.
+func oidcJWTFromEnv() (string, error) {
+	tokenEnv := os.Getenv("INFISICAL_OIDC_AUTH_TOKEN_KEY_NAME")
+	if tokenEnv == "" {
+		tokenEnv = "INFISICAL_AUTH_JWT"
+	}
+
+	jwt := os.Getenv(tokenEnv)
+	if jwt == "" && tokenEnv != "INFISICAL_JWT" {
+		jwt = os.Getenv("INFISICAL_JWT")
+	}
+	if jwt == "" {
+		return "", fmt.Errorf("OIDC_AUTH requires an OIDC JWT: set %s (or INFISICAL_JWT)", tokenEnv)
+	}
+
+	return jwt, nil
 }
 
 func parseAuthMethod(s string) (util.AuthMethod, error) {
@@ -98,7 +126,8 @@ func parseAuthMethod(s string) (util.AuthMethod, error) {
 		util.GCP_IAM,
 		util.AWS_IAM,
 		util.KUBERNETES,
-		util.AZURE:
+		util.AZURE,
+		util.OIDC_AUTH:
 		return authMethod, nil
 	default:
 		return "", fmt.Errorf("invalid value of INFISICAL_AUTH_METHOD: %q", s)

--- a/pkg/providers/infisical/infisical.go
+++ b/pkg/providers/infisical/infisical.go
@@ -44,8 +44,11 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 
 	path := cfg.String("path")
 
-	if path != "" && !strings.HasPrefix(path, "/") {
-		p.path = "/" + path
+	if path != "" {
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		p.path = path
 	}
 
 	return p

--- a/pkg/providers/infisical/infisical.go
+++ b/pkg/providers/infisical/infisical.go
@@ -44,11 +44,8 @@ func New(l *log.Logger, cfg api.StaticConfig) *provider {
 
 	path := cfg.String("path")
 
-	if path != "" {
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
-		p.path = path
+	if path != "" && !strings.HasPrefix(path, "/") {
+		p.path = "/" + path
 	}
 
 	return p


### PR DESCRIPTION
## Desc

`vals` doesn't work currently if you are using OIDC for access to infisical. Infisical natively supports this using it's envvars, but that isn't exposed in the switch case in `infisical.go`.

Note: `cursor` was partially used for PR generation.